### PR TITLE
calculators now show an error if they do not exist

### DIFF
--- a/netbeans/libxtp/nbproject/configurations.xml
+++ b/netbeans/libxtp/nbproject/configurations.xml
@@ -853,8 +853,6 @@
       </item>
       <item path="../../src/libxtp/toolfactory.cc" ex="false" tool="1" flavor2="0">
       </item>
-      <item path="../../src/libxtp/tools/coupling.h" ex="false" tool="3" flavor2="0">
-      </item>
       <item path="../../src/libxtp/tools/dft.h" ex="false" tool="3" flavor2="0">
       </item>
       <item path="../../src/libxtp/tools/exciton.cc" ex="false" tool="1" flavor2="0">
@@ -895,6 +893,20 @@
       <item path="../../src/libxtp/version_nb.cc" ex="false" tool="1" flavor2="0">
       </item>
       <item path="../../src/libxtp/xtpapplication.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/Md2QmEngine.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/Md2QmEngine.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_dump.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_map.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_parallel.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_run.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_tools.cc" ex="false" tool="1" flavor2="0">
       </item>
     </conf>
     <conf name="Release" type="3">
@@ -1505,8 +1517,6 @@
       </item>
       <item path="../../src/libxtp/toolfactory.cc" ex="false" tool="1" flavor2="0">
       </item>
-      <item path="../../src/libxtp/tools/coupling.h" ex="false" tool="3" flavor2="0">
-      </item>
       <item path="../../src/libxtp/tools/dft.h" ex="false" tool="3" flavor2="0">
       </item>
       <item path="../../src/libxtp/tools/exciton.cc" ex="false" tool="1" flavor2="0">
@@ -1547,6 +1557,20 @@
       <item path="../../src/libxtp/version_nb.cc" ex="false" tool="1" flavor2="0">
       </item>
       <item path="../../src/libxtp/xtpapplication.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/Md2QmEngine.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/Md2QmEngine.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_dump.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_map.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_parallel.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_run.cc" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="../../src/tools/xtp_tools.cc" ex="false" tool="1" flavor2="0">
       </item>
     </conf>
   </confs>

--- a/src/tools/xtp_dump.cc
+++ b/src/tools/xtp_dump.cc
@@ -147,6 +147,7 @@ bool XtpDump::EvaluateOptions() {
     tools::Tokenizer calcs(OptionsMap()["extract"].as<string>(), " ,\n\t");
     tools::Tokenizer::iterator it;
     for (it = calcs.begin(); it != calcs.end(); it++) {
+      
       bool _found_calc = false;
       for (xtp::ExtractorFactory::assoc_map::const_iterator iter = xtp::Extractors().getObjects().begin();
               iter != xtp::Extractors().getObjects().end(); ++iter) {
@@ -163,15 +164,19 @@ bool XtpDump::EvaluateOptions() {
                 iter != ctp::Extractors().getObjects().end(); ++iter) {
 
           if ((*it).compare((iter->first).c_str()) == 0) {
+            _found_calc = true;
             cout << " This is a CTP app" << endl;
             xtp::SqlApplication::AddCalculator(ctp::Extractors().Create((*it).c_str()));
           }
-        }
       }
-
-
     }
-    return true;
+    if (!_found_calc) {
+      cout << "Extractor " << *it << " does not exist\n";
+      StopExecution();
+    }
+
+  }
+  return true;
   }
 
 int main(int argc, char** argv) {

--- a/src/tools/xtp_parallel.cc
+++ b/src/tools/xtp_parallel.cc
@@ -158,19 +158,20 @@ bool XtpParallel::EvaluateOptions() {
                 _found_calc = true;
             } 
         }
-        if ( !_found_calc ){
-        for(ctp::JobCalculatorfactory::assoc_map::const_iterator iter=ctp::JobCalculators().getObjects().begin(); 
-                        iter != ctp::JobCalculators().getObjects().end(); ++iter) {
-        
-            if ( (*it).compare( (iter->first).c_str() ) == 0 ) {
-                cout << " This is a CTP app" << endl;
-                xtp::JobApplication::AddCalculator(ctp::JobCalculators().Create((*it).c_str()));
-            } 
+        if (!_found_calc) {
+      for (ctp::JobCalculatorfactory::assoc_map::const_iterator iter = ctp::JobCalculators().getObjects().begin();
+              iter != ctp::JobCalculators().getObjects().end(); ++iter) {
+
+        if ((*it).compare((iter->first).c_str()) == 0) {
+          cout << " This is a CTP app" << endl;
+          xtp::JobApplication::AddCalculator(ctp::JobCalculators().Create((*it).c_str()));
         }
-        
-         
-         
-        }
+      }
+    }
+    if (!_found_calc) {
+      cout << "Jobcalculator " << *it << " does not exist\n";
+      StopExecution();
+    }
     }
     
     return true;

--- a/src/tools/xtp_run.cc
+++ b/src/tools/xtp_run.cc
@@ -169,13 +169,19 @@ bool XtpRun::EvaluateOptions() {
               iter != ctp::Calculators().getObjects().end(); ++iter) {
 
         if ((*it).compare((iter->first).c_str()) == 0) {
+          _found_calc = true;
           cout << " This is a CTP app" << endl;
           xtp::SqlApplication::AddCalculator(ctp::Calculators().Create((*it).c_str()));
         }
       }
     }
-
-    load_property_from_xml(_options, _op_vm["options"].as<string>());
+    if(!_found_calc){
+      cout << "Calculator " << *it << " does not exist\n";
+      StopExecution();
+    }
+    else{
+      load_property_from_xml(_options, _op_vm["options"].as<string>());
+    }
   }
     return true;
   }

--- a/src/tools/xtp_tools.cc
+++ b/src/tools/xtp_tools.cc
@@ -187,8 +187,12 @@ bool XtpTools::EvaluateOptions() {
         }
       }
     }
-    cout << "Registered " << (*it).c_str() << endl;
-
+    if (!_found_calc) {
+      cout << "Tool " << *it << " does not exist\n";
+      StopExecution();
+    }else{
+      cout << "Registered " << (*it).c_str() << endl;
+    }
   }
   return 1;
 }


### PR DESCRIPTION
Calculators, jobcalculators, tools and dump now throw an error if calculator does not exist, before only happened when listing now also happens on execution