### PR TITLE
should add electron when occ != 0

### DIFF
--- a/src/libxtp/qmpackages/nwchem.cc
+++ b/src/libxtp/qmpackages/nwchem.cc
@@ -535,7 +535,7 @@ namespace votca {
             for (i = 1; i <= _n_lines; i++) {
                 for (int j = 0; j < 3; j++) {
                     _input_file >> _occ[ _imo ];
-                    if (_occ[ _imo ] == 2.0) {
+                    if (_occ[ _imo ] != 0.0) {
                         _number_of_electrons++;
                     }
                     _imo++;


### PR DESCRIPTION
I think I caught an error in the nwchem parser.
The parser adds electron only if the occupation number is equal to two. But I generated calculations were these numbers were equal to one. Checking with the main log file, it thus makes sense to me that electrons should be counted if the occupation number is different than 0.

But I don't know so well nwchem, it should be checked.