### PR TITLE
Enforced uniform header guards across public facing header files

### DIFF
--- a/include/votca/xtp/ERIs.h
+++ b/include/votca/xtp/ERIs.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_ERIS_H
-#define	_VOTCA_XTP_ERIS_H
+#ifndef VOTCA_XTP_ERIS_H
+#define	VOTCA_XTP_ERIS_H
 
 
 #include <votca/xtp/threecenter.h>
@@ -92,5 +92,5 @@ namespace votca { namespace xtp {
 
 }}
 
-#endif	/* ERIS_H */
+#endif	// VOTCA_XTP_ERIS_H
 

--- a/include/votca/xtp/Md2QmEngine.h
+++ b/include/votca/xtp/Md2QmEngine.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _MD2QMENGINE_H
-#define _MD2QMENGINE_H
+#ifndef VOTCA_XTP_MD2QMENGINE_H
+#define VOTCA_XTP_MD2QMENGINE_H
 
 #include <votca/xtp/calculatorfactory.h>
 #include <votca/tools/property.h>
@@ -90,4 +90,4 @@ private:
 
 };
 
-#endif /* _MD2QMENGINE_H */
+#endif // VOTCA_XTP_MD2QMENGINE_H

--- a/include/votca/xtp/adiis_costfunction.h
+++ b/include/votca/xtp/adiis_costfunction.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_ADIIS_COSTFUNCTION__H
-#define __XTP_ADIIS_COSTFUNCTION__H
+#ifndef VOTCA_XTP_ADIIS_COSTFUNCTION_H
+#define VOTCA_XTP_ADIIS_COSTFUNCTION_H
 
 
 #include <votca/xtp/basisset.h>
@@ -77,4 +77,4 @@ namespace votca {
 
     }
 }
-#endif /* FORCES_H */
+#endif // VOTCA_XTP_ADIIS_COSTFUNCTION_H

--- a/include/votca/xtp/aobasis.h
+++ b/include/votca/xtp/aobasis.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_AOBASIS__H
-#define	__XTP_AOBASIS__H
+#ifndef VOTCA_XTP_AOBASIS_H
+#define	VOTCA_XTP_AOBASIS_H
 
 
 #include <boost/math/constants/constants.hpp>
@@ -111,5 +111,5 @@ private:
  
 }}
 
-#endif	/* AOBASIS_H */
+#endif	// VOTCA_XTP_AOBASIS_H
 

--- a/include/votca/xtp/aomatrix.h
+++ b/include/votca/xtp/aomatrix.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_AOMATRIX__H
-#define	__XTP_AOMATRIX__H
+#ifndef VOTCA_XTP_AOMATRIX_H
+#define VOTCA_XTP_AOMATRIX_H
 
 #include <votca/xtp/aobasis.h>
 #include <votca/xtp/aoshell.h>
@@ -234,5 +234,5 @@ namespace votca { namespace xtp {
     
 }}
 
-#endif	/* AOMATRIX_H */
+#endif	// VOTCA_XTP_AOMATRIX_H
 

--- a/include/votca/xtp/aoshell.h
+++ b/include/votca/xtp/aoshell.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_AOSHELL__H
-#define	__XTP_AOSHELL__H
+#ifndef VOTCA_XTP_AOSHELL_H
+#define	VOTCA_XTP_AOSHELL_H
 
 
 #include <boost/math/constants/constants.hpp>
@@ -163,5 +163,6 @@ private:
     
 }}
 
-#endif	/* AOSHELL_H */
+#endif	// VOTCA_XTP_AOSHELL_H
+
 

--- a/include/votca/xtp/apolarsite.h
+++ b/include/votca/xtp/apolarsite.h
@@ -17,8 +17,8 @@
  *
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
-#ifndef __VOTCA_XTP_APOLARSITE_H
-#define __VOTCA_XTP_APOLARSITE_H
+#ifndef VOTCA_XTP_APOLARSITE_H
+#define VOTCA_XTP_APOLARSITE_H
 
 #include <cstdlib>
 #include <fstream>
@@ -604,4 +604,5 @@ private:
 }}
 
 
-#endif
+#endif // VOTCA_XTP_APOLARSITE_H
+

--- a/include/votca/xtp/atom.h
+++ b/include/votca/xtp/atom.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_ATOM_H
-#define __VOTCA_XTP_ATOM_H
+#ifndef VOTCA_XTP_ATOM_H
+#define VOTCA_XTP_ATOM_H
 
 #include <string>
 #include <map>
@@ -199,4 +199,4 @@ inline void Atom::setQMPart(const int &qmid, tools::vec qmPos) {
 }
 }
 
-#endif /* __VOTCA_XTP_ATOM_H */
+#endif // VOTCA_XTP_ATOM_H 

--- a/include/votca/xtp/basisset.h
+++ b/include/votca/xtp/basisset.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_BASISSET__H
-#define	__XTP_BASISSET__H
+#ifndef VOTCA_XTP_BASISSET_H
+#define	VOTCA_XTP_BASISSET_H
 
 #include <string>
 #include <map>
@@ -204,5 +204,6 @@ private:
 
 }}
 
-#endif	/* BASISSET_H */
+#endif	// VOTCA_XTP_BASISSET_H
+
 

--- a/include/votca/xtp/bfgs-trm.h
+++ b/include/votca/xtp/bfgs-trm.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_BFGSTRM__H
-#define __XTP_BFGSTRM__H
+#ifndef VOTCA_XTP_BFGSTRM_H
+#define VOTCA_XTP_BFGSTRM_H
 
 #include <votca/xtp/optimiser_costfunction.h>
 #include <votca/xtp/logger.h>
@@ -96,4 +96,4 @@ namespace votca {
 
     }
 }
-#endif /* BFGSTRM_H */
+#endif // VOTCA_XTP_BFGSTRM_H

--- a/include/votca/xtp/bse.h
+++ b/include/votca/xtp/bse.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_BSE_H
-#define _VOTCA_XTP_BSE_H
+#ifndef VOTCA_XTP_BSE_H
+#define VOTCA_XTP_BSE_H
 
 #include <votca/xtp/orbitals.h>
 #include <votca/xtp/ppm.h>
@@ -172,4 +172,4 @@ xtp::Logger *_log;
 }
 }
 
-#endif /* _VOTCA_XTP_BSE_H */
+#endif // VOTCA_XTP_BSE_H

--- a/include/votca/xtp/bsecoupling.h
+++ b/include/votca/xtp/bsecoupling.h
@@ -20,8 +20,8 @@
 #include <votca/xtp/couplingbase.h>
 #include <votca/xtp/qmstate.h>
 
-#ifndef _VOTCA_XTP_BSECOUPLING_H
-#define	_VOTCA_XTP_BSECOUPLING_H
+#ifndef VOTCA_XTP_BSECOUPLING_H
+#define	VOTCA_XTP_BSECOUPLING_H
 
 namespace votca { namespace xtp {
 
@@ -94,6 +94,6 @@ private:
 
 }}
 
-#endif	/* _VOTCA_XTP_BSECOUPLING_H */
+#endif	// VOTCA_XTP_BSECOUPLING_H
 
 

--- a/include/votca/xtp/calculatorfactory.h
+++ b/include/votca/xtp/calculatorfactory.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_CALCULATORFACTORY_H
-#define	__VOTCA_XTP_CALCULATORFACTORY_H
+#ifndef VOTCA_XTP_CALCULATORFACTORY_H
+#define	VOTCA_XTP_CALCULATORFACTORY_H
 
 #include <map>
 #include <votca/tools/objectfactory.h>
@@ -64,5 +64,6 @@ inline xtp::QMCalculator* Calculatorfactory::Create(const std::string &key){
 
 }}
 
-#endif	/* _Calculatorfactory_H */
+#endif // VOTCA_XTP_CALCULATORFACTORY_H
+
 

--- a/include/votca/xtp/chargecarrier.h
+++ b/include/votca/xtp/chargecarrier.h
@@ -16,8 +16,8 @@
  * author: Kordt
  */
 
-#ifndef __VOTCA_CHARGECARRIER_H
-#define	__VOTCA_CHARGECARRIER_H
+#ifndef VOTCA_XTP_CHARGECARRIER_H
+#define	VOTCA_XTP_CHARGECARRIER_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/gnode.h>
@@ -73,4 +73,4 @@ namespace votca { namespace xtp {
 }}
 
 
-#endif	/* __VOTCA_CHARGECARRIER_H */
+#endif	// VOTCA_XTP_CHARGECARRIER_H

--- a/include/votca/xtp/checkpoint.h
+++ b/include/votca/xtp/checkpoint.h
@@ -14,8 +14,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_CHECKPOINT_H
-#define _VOTCA_XTP_CHECKPOINT_H
+#ifndef VOTCA_XTP_CHECKPOINT_H
+#define VOTCA_XTP_CHECKPOINT_H
 
 
 #include <H5Cpp.h>
@@ -44,4 +44,4 @@ class CheckpointFile {
 
 }  // namespace xtp
 }  // namespace votca
-#endif  // _VOTCA_XTP_CHECKPOINT_H
+#endif  // VOTCA_XTP_CHECKPOINT_H

--- a/include/votca/xtp/checkpointreader.h
+++ b/include/votca/xtp/checkpointreader.h
@@ -13,8 +13,8 @@
  * limitations under the License.
  *
  */
-#ifndef _VOTCA_XTP_CHECKPOINT_READER_H
-#define _VOTCA_XTP_CHECKPOINT_READER_H
+#ifndef VOTCA_XTP_CHECKPOINT_READER_H
+#define VOTCA_XTP_CHECKPOINT_READER_H
 
 #include <votca/xtp/eigen.h>
 #include <H5Cpp.h>
@@ -163,4 +163,4 @@ private:
 }  // namespace xtp
 }  // namespace votca
 
-#endif  // _VOTCA_XTP_CHECKPOINT_READER_H
+#endif  // VOTCA_XTP_CHECKPOINT_READER_H

--- a/include/votca/xtp/checkpointwriter.h
+++ b/include/votca/xtp/checkpointwriter.h
@@ -14,8 +14,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_CHECKPOINT_WRITER_H
-#define _VOTCA_XTP_CHECKPOINT_WRITER_H
+#ifndef VOTCA_XTP_CHECKPOINT_WRITER_H
+#define VOTCA_XTP_CHECKPOINT_WRITER_H
 
 #include <votca/xtp/eigen.h>
 #include <map>
@@ -174,4 +174,4 @@ private:
 };
 }  // namespace xtp
 }  // namespace votca
-#endif  // _VOTCA_XTP_CHECKPOINT_WRITER_H
+#endif  // VOTCA_XTP_CHECKPOINT_WRITER_H

--- a/include/votca/xtp/convergenceacc.h
+++ b/include/votca/xtp/convergenceacc.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_CONVERGENCEACC__H
-#define _VOTCA_XTP_CONVERGENCEACC__H
+#ifndef VOTCA_XTP_CONVERGENCEACC_H
+#define VOTCA_XTP_CONVERGENCEACC_H
 
 #include <votca/xtp/basisset.h>
 #include <votca/xtp/logger.h>
@@ -137,5 +137,5 @@ class ConvergenceAcc{
  
 }}
 
-#endif	
+#endif // VOTCA_XTP_CONVERGENCEACC_H	
 

--- a/include/votca/xtp/couplingbase.h
+++ b/include/votca/xtp/couplingbase.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_COUPLINGBASE_H
-#define	_VOTCA_XTP_COUPLINGBASE_H
+#ifndef VOTCA_XTP_COUPLINGBASE_H
+#define	VOTCA_XTP_COUPLINGBASE_H
 
 #include <votca/xtp/orbitals.h>
 #include <votca/xtp/logger.h>
@@ -113,6 +113,7 @@ inline void CouplingBase::CheckAtomCoordinates(const Orbitals& orbitalsA,
 
 }}
 
-#endif	/* _VOTCA_XTP_DFTCOUPLING_H */
+#endif	// VOTCA_XTP_COUPLINGBASE_H
+
 
 

--- a/include/votca/xtp/dftcoupling.h
+++ b/include/votca/xtp/dftcoupling.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_DFTCOUPLING_H
-#define	_VOTCA_XTP_DFTCOUPLING_H
+#ifndef VOTCA_XTP_DFTCOUPLING_H
+#define	VOTCA_XTP_DFTCOUPLING_H
 
 #include <votca/xtp/couplingbase.h>
 
@@ -73,6 +73,6 @@ private:
 
 }}
 
-#endif	/* _VOTCA_XTP_DFTCOUPLING_H */
+#endif	// VOTCA_XTP_DFTCOUPLING_H
 
 

--- a/include/votca/xtp/dftengine.h
+++ b/include/votca/xtp/dftengine.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_DFTENGINE_H
-#define _VOTCA_XTP_DFTENGINE_H
+#ifndef VOTCA_XTP_DFTENGINE_H
+#define VOTCA_XTP_DFTENGINE_H
 
 #include <votca/xtp/numerical_integrations.h>
 #include <boost/filesystem.hpp>
@@ -209,4 +209,4 @@ namespace votca {
     }
 }
 
-#endif /* _VOTCA_XTP_DFTENGINE_H */
+#endif // VOTCA_XTP_DFTENGINE_H

--- a/include/votca/xtp/diis.h
+++ b/include/votca/xtp/diis.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_DIIS__H
-#define _VOTCA_XTP_DIIS__H
+#ifndef VOTCA_XTP_DIIS_H
+#define VOTCA_XTP_DIIS_H
 
 
 
@@ -68,5 +68,5 @@ public:
     
 }}
 
-#endif	
+#endif // VOTCA_XTP_DIIS_H	
 

--- a/include/votca/xtp/dmaspace.h
+++ b/include/votca/xtp/dmaspace.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_DMASPACE_H
-#define __VOTCA_XTP_DMASPACE_H
+#ifndef VOTCA_XTP_DMASPACE_H
+#define VOTCA_XTP_DMASPACE_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/ewdspace.h>
@@ -330,4 +330,4 @@ public:
 
 }}}
 
-#endif // __VOTCA_XTP_DMASPACE_H
+#endif // VOTCA_XTP_DMASPACE_H

--- a/include/votca/xtp/eigen.h
+++ b/include/votca/xtp/eigen.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_EIGEN__H
-#define	__XTP_EIGEN__H
+#ifndef VOTCA_XTP_EIGEN_H
+#define	VOTCA_XTP_EIGEN_H
 #include <votca/tools/eigen.h>
 #include <votca/xtp/votca_config.h>
 #if (GWBSE_DOUBLE)
@@ -41,5 +41,5 @@ namespace votca {
 
 
 
-#endif	/*XTP_EIGEN__H */
+#endif	// VOTCA_XTP_EIGEN_H 
 

--- a/include/votca/xtp/energy_costfunction.h
+++ b/include/votca/xtp/energy_costfunction.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_ENERGY_COSTFUNCTION__H
-#define __XTP_ENERGY_COSTFUNCTION__H
+#ifndef VOTCA_XTP_ENERGY_COSTFUNCTION_H
+#define VOTCA_XTP_ENERGY_COSTFUNCTION_H
 
 #include <votca/xtp/optimiser_costfunction.h>
 
@@ -105,4 +105,4 @@ namespace votca {
 
     }
 }
-#endif /* FORCES_H */
+#endif // VOTCA_XTP_ENERGY_COSTFUNCTION_H

--- a/include/votca/xtp/esp2multipole.h
+++ b/include/votca/xtp/esp2multipole.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_ESP2MULTIPOLE_H
-#define _VOTCA_XTP_ESP2MULTIPOLE_H
+#ifndef VOTCA_XTP_ESP2MULTIPOLE_H
+#define VOTCA_XTP_ESP2MULTIPOLE_H
 
 #include <stdio.h>
 #include <votca/xtp/espfit.h>
@@ -79,4 +79,4 @@ private:
 }}
 
 
-#endif
+#endif // VOTCA_XTP_ESP2MULTIPOLE_H

--- a/include/votca/xtp/espfit.h
+++ b/include/votca/xtp/espfit.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_ESPFIT__H
-#define	__VOTCA_XTP_ESPFIT__H
+#ifndef VOTCA_XTP_ESPFIT_H
+#define	VOTCA_XTP_ESPFIT_H
 
 
 #include <votca/tools/elements.h>

--- a/include/votca/xtp/ewaldactor.h
+++ b/include/votca/xtp/ewaldactor.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef _VOTCA_XTP_EWDINTERACTOR_H
-#define	_VOTCA_XTP_EWDINTERACTOR_H
+#ifndef VOTCA_XTP_EWDINTERACTOR_H
+#define	VOTCA_XTP_EWDINTERACTOR_H
 
 #include <cmath>
 #include <votca/tools/vec.h>
@@ -1593,6 +1593,6 @@ inline void EwdInteractor::UApplyBiasK(APolarSite &p) {
 
 }}
 
-#endif // _VOTCA_XTP_EWDINTERACTOR_H
+#endif // VOTCA_XTP_EWDINTERACTOR_H
 
 

--- a/include/votca/xtp/ewaldnd.h
+++ b/include/votca/xtp/ewaldnd.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_EWALDND_H
-#define __VOTCA_XTP_EWALDND_H
+#ifndef VOTCA_XTP_EWALDND_H
+#define VOTCA_XTP_EWALDND_H
 
 #include <votca/xtp/ewaldactor.h>
 #include <votca/xtp/xjob.h>
@@ -301,4 +301,4 @@ protected:
 }}
 
 
-#endif // __VOTCA_XTP_EWALDND_H
+#endif // VOTCA_XTP_EWALDND_H

--- a/include/votca/xtp/ewdspace.h
+++ b/include/votca/xtp/ewdspace.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_EWDSPACE_H
-#define __VOTCA_XTP_EWDSPACE_H
+#ifndef VOTCA_XTP_EWDSPACE_H
+#define VOTCA_XTP_EWDSPACE_H
 
 #include <cmath>
 #include <votca/tools/vec.h>
@@ -274,4 +274,4 @@ inline bool VectorSort<Norm,V>::operator() (const V *v1,
 
 }}}
 
-#endif // __VOTCA_XTP_EWDSPACE_H
+#endif // VOTCA_XTP_EWDSPACE_H

--- a/include/votca/xtp/extractorfactory.h
+++ b/include/votca/xtp/extractorfactory.h
@@ -66,5 +66,5 @@ inline QMCalculator* ExtractorFactory::Create(const std::string &key)
 
 }}
 
-#endif	/* VOTCA_XTP_EXTRACTORFACTORY_H.h */
+#endif	// VOTCA_XTP_EXTRACTORFACTORY_H
 

--- a/include/votca/xtp/forces.h
+++ b/include/votca/xtp/forces.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_FORCES__H
-#define __XTP_FORCES__H
+#ifndef VOTCA_XTP_FORCES_H
+#define VOTCA_XTP_FORCES_H
 
 
 #include <votca/xtp/qmatom.h>
@@ -75,4 +75,4 @@ namespace votca {
 
     }
 }
-#endif /* FORCES_H */
+#endif // VOTCA_XTP_FORCES_H

--- a/include/votca/xtp/fourcenter.h
+++ b/include/votca/xtp/fourcenter.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_FOURCENTER__H
-#define	__XTP_FOURCENTER__H
+#ifndef VOTCA_XTP_FOURCENTER_H
+#define	VOTCA_XTP_FOURCENTER_H
 
 
 #include <votca/xtp/eigen.h>
@@ -50,5 +50,5 @@ namespace votca { namespace xtp {
 
 }}
 
-#endif	/* FOURCENTER_H */
+#endif	// VOTCA_XTP_FOURCENTER_H
 

--- a/include/votca/xtp/fragment.h
+++ b/include/votca/xtp/fragment.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_FRAGMENT_H
-#define	__VOTCA_XTP_FRAGMENT_H
+#ifndef VOTCA_XTP_FRAGMENT_H
+#define	VOTCA_XTP_FRAGMENT_H
 
 #include <vector>
 #include <string>
@@ -125,5 +125,5 @@ private:
 
 }}
 
-#endif	/* __VOTCA_XTP_FRAGMENT_H */
+#endif	// VOTCA_XTP_FRAGMENT_H 
 

--- a/include/votca/xtp/gdma.h
+++ b/include/votca/xtp/gdma.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_GDMA_H
-#define	__VOTCA_XTP_GDMA_H
+#ifndef VOTCA_XTP_GDMA_H
+#define	VOTCA_XTP_GDMA_H
 
 #include <string>
 #include <map>
@@ -77,5 +77,5 @@ private:
 };
 }}
 
-#endif	/* __VOTCA_XTP_GDMA_H */
+#endif	// VOTCA_XTP_GDMA_H 
 

--- a/include/votca/xtp/geometry_optimization.h
+++ b/include/votca/xtp/geometry_optimization.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_GEOMETRY_OPTIMIZATION__H
-#define __XTP_GEOMETRY_OPTIMIZATION__H
+#ifndef XTP_GEOMETRY_OPTIMIZATION_H
+#define XTP_GEOMETRY_OPTIMIZATION_H
 
 
 #include <votca/xtp/qmatom.h>
@@ -73,4 +73,4 @@ namespace votca {
 
     }
 }
-#endif /* GEOMETRY_OPTIMIZATION_H */
+#endif // VOTCA_XTP_GEOMETRY_OPTIMIZATION_H 

--- a/include/votca/xtp/glink.h
+++ b/include/votca/xtp/glink.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _VOTCA_KMC_GLINK_H
-#define _VOTCA_KMC_GLINK_H
+#ifndef VOTCA_XTP_GLINK_H
+#define VOTCA_XTP_GLINK_H
 #include <votca/tools/vec.h>
 
 namespace votca {
@@ -35,4 +35,4 @@ struct GLink {
 }
 }
 
-#endif  // _VOTCA_KMC_GLINK_H
+#endif  // VOTCA_XTP_GLINK_H

--- a/include/votca/xtp/gnode.h
+++ b/include/votca/xtp/gnode.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef _VOTCA_KMC_GNODE_H
-#define	_VOTCA_KMC_GNODE_H
+#ifndef VOTCA_XTP_GNODE_H
+#define	VOTCA_XTP_GNODE_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/glink.h>
@@ -61,5 +61,5 @@ class GNode
 
 }}
 
-#endif	/* _VOTCA_KMC_GNODE_H */
+#endif	// VOTCA_XTP_GNODE_H
 

--- a/include/votca/xtp/grid.h
+++ b/include/votca/xtp/grid.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_GRID__H
-#define	__XTP_GRID__H
+#ifndef VOTCA_XTP_GRID_H
+#define	VOTCA_XTP_GRID_H
 
 
 #include <votca/tools/elements.h>
@@ -74,4 +74,4 @@ namespace votca { namespace xtp {
     
 }}
 
-#endif	/* GRID_H */
+#endif	// VOTCA_XTP_GRID_H

--- a/include/votca/xtp/grid_containers.h
+++ b/include/votca/xtp/grid_containers.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_GRID_CONTAINERS__H
-#define	__XTP_GRID_CONTAINERS__H
+#ifndef VOTCA_XTP_GRID_CONTAINERS_H
+#define	VOTCA_XTP_GRID_CONTAINERS_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/aobasis.h>
@@ -63,4 +63,4 @@ namespace votca { namespace xtp {
         };
 
     }}
-#endif	/* NUMERICAL_INTEGRATION_H */
+#endif	// VOTCA_XTP_GRID_CONTAINERS_H 

--- a/include/votca/xtp/gridbox.h
+++ b/include/votca/xtp/gridbox.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_GRIDBOX__H
-#define	__XTP_GRIDBOX__H
+#ifndef VOTCA_XTP_GRIDBOX_H
+#define	VOTCA_XTP_GRIDBOX_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/grid_containers.h>
@@ -125,4 +125,5 @@ namespace votca { namespace xtp {
        
 
     }}
-#endif	/* NUMERICAL_INTEGRATION_H */
+#endif	// VOTCA_XTP_GRIDBOX_H
+

--- a/include/votca/xtp/gwbse.h
+++ b/include/votca/xtp/gwbse.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_GWBSE_H
-#define _VOTCA_XTP_GWBSE_H
+#ifndef VOTCA_XTP_GWBSE_H
+#define VOTCA_XTP_GWBSE_H
 #include <votca/xtp/logger.h>
 #include <votca/tools/property.h>
 #include <fstream>
@@ -125,4 +125,4 @@ class GWBSE {
 }
 }
 
-#endif /* _VOTCA_XTP_GWBSE_H */
+#endif // VOTCA_XTP_GWBSE_H 

--- a/include/votca/xtp/gwbseengine.h
+++ b/include/votca/xtp/gwbseengine.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_GWBSEENGINE_H
-#define _VOTCA_XTP_GWBSEENGINE_H
+#ifndef VOTCA_XTP_GWBSEENGINE_H
+#define VOTCA_XTP_GWBSEENGINE_H
 
 #include <votca/xtp/segment.h>
 #include <votca/xtp/polarseg.h>
@@ -107,4 +107,4 @@ namespace votca {
     }
 }
 
-#endif /* _VOTCA_XTP_GWBSEENGINE_H */
+#endif // VOTCA_XTP_GWBSEENGINE_H 

--- a/include/votca/xtp/gyration.h
+++ b/include/votca/xtp/gyration.h
@@ -17,8 +17,8 @@
  */
 
 
-#ifndef _VOTCA_XTP_GYRATION_H
-#define _VOTCA_XTP_GYRATION_H
+#ifndef VOTCA_XTP_GYRATION_H
+#define VOTCA_XTP_GYRATION_H
 
 
 #include <stdio.h>
@@ -60,5 +60,6 @@ private:
 
 
 
-#endif /* _MUSCET_XTP_GYRATION_H */
+#endif // VOTCA_XTP_GYRATION_H
+
 

--- a/include/votca/xtp/job.h
+++ b/include/votca/xtp/job.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_JOB_H
-#define	__VOTCA_XTP_JOB_H
+#ifndef VOTCA_XTP_JOB_H
+#define	VOTCA_XTP_JOB_H
 
 #include <iostream>
 #include <fstream>
@@ -143,4 +143,4 @@ protected:
 }}
 
 
-#endif // __VOTCA_XTP_JOB_H
+#endif // VOTCA_XTP_JOB_H

--- a/include/votca/xtp/jobapplication.h
+++ b/include/votca/xtp/jobapplication.h
@@ -71,7 +71,8 @@ protected:
 
 
 
-#endif /* _QMApplication_H */
+#endif // VOTCA_XTP_JOBAPPLICATION
+
 
 
 

--- a/include/votca/xtp/jobcalculator.h
+++ b/include/votca/xtp/jobcalculator.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_JOBCALCULATOR_H
-#define __VOTCA_XTP_JOBCALCULATOR_H
+#ifndef VOTCA_XTP_JOBCALCULATOR_H
+#define VOTCA_XTP_JOBCALCULATOR_H
 
 
 #include <votca/xtp/qmcalculator.h>
@@ -55,5 +55,5 @@ protected:
 
 }}
 
-#endif // __VOTCA_XTP_JOBCALCULATOR_H
+#endif // VOTCA_XTP_JOBCALCULATOR_H
 

--- a/include/votca/xtp/jobcalculatorfactory.h
+++ b/include/votca/xtp/jobcalculatorfactory.h
@@ -66,5 +66,5 @@ inline xtp::JobCalculator* JobCalculatorfactory::Create(const std::string &key)
 
 }}
 
-#endif	/* _Calculatorfactory_H */
+#endif	// VOTCA_XTP_JOBCALCULATORFACTORY_H
 

--- a/include/votca/xtp/kmccalculator.h
+++ b/include/votca/xtp/kmccalculator.h
@@ -16,8 +16,8 @@
  * author: Kordt
  */
 
-#ifndef __VOTCA_KMC_CALCULATOR_H
-#define	__VOTCA_KMC_CALCULATOR_H
+#ifndef VOTCA_XTP_CALCULATOR_H
+#define	VOTCA_XTP_CALCULATOR_H
 
 // #include <votca/xtp/vssmgroup.h>
 #include <vector>
@@ -113,4 +113,4 @@ protected:
 }}
 
 
-#endif	/* __VOTCA_KMC_MULTIPLE_H */
+#endif	// VOTCA_XTP_CALCULATOR_H

--- a/include/votca/xtp/logger.h
+++ b/include/votca/xtp/logger.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_LOG_H
-#define	__VOTCA_XTP_LOG_H
+#ifndef VOTCA_XTP_LOG_H
+#define	VOTCA_XTP_LOG_H
 
 #include <sstream>
 #include <iostream>
@@ -251,4 +251,4 @@ class TimeStamp
 
 }}
 
-#endif // __VOTCA_XTP_LOG_H
+#endif // VOTCA_XTP_LOG_H

--- a/include/votca/xtp/lowdin.h
+++ b/include/votca/xtp/lowdin.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_LOWDIN__H
-#define	__XTP_LOWDIN__H
+#ifndef VOTCA_XTP_LOWDIN_H
+#define	VOTCA_XTP_LOWDIN_H
 
 
 #include <votca/tools/elements.h>
@@ -57,4 +57,4 @@ private:
 
 }}
 
-#endif	/* ESPFIT_H */
+#endif	// VOTCA_XTP_LOWDIN_H

--- a/include/votca/xtp/molpolengine.h
+++ b/include/votca/xtp/molpolengine.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_MOLPOLENGINE_H
-#define __VOTCA_XTP_MOLPOLENGINE_H
+#ifndef VOTCA_XTP_MOLPOLENGINE_H
+#define VOTCA_XTP_MOLPOLENGINE_H
 
 #include <votca/xtp/polartop.h>
 
@@ -53,4 +53,4 @@ private:
 
 }}
 
-#endif // __VOTCA_XTP_MOLPOLENGINE_H
+#endif // VOTCA_XTP_MOLPOLENGINE_H

--- a/include/votca/xtp/mulliken.h
+++ b/include/votca/xtp/mulliken.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_MULLIKEN__H
-#define	__XTP_MULLIKEN__H
+#ifndef VOTCA_XTP_MULLIKEN_H
+#define VOTCA_XTP_MULLIKEN_H
 
 
 #include <votca/tools/elements.h>
@@ -58,4 +58,4 @@ public:
 
 }}
 
-#endif	/* ESPFIT_H */
+#endif	// VOTCA_XTP_MULLIKEN_H

--- a/include/votca/xtp/multiarray.h
+++ b/include/votca/xtp/multiarray.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_MULTIARRAY__H
-#define	__XTP_MULTIARRAY__H
+#ifndef VOTCA_XTP_MULTIARRAY_H
+#define	VOTCA_XTP_MULTIARRAY_H
 
 #define BOOST_DISABLE_ASSERTS 
 #include <boost/multi_array.hpp>
@@ -38,5 +38,5 @@ typedef tensor4d::index index4d; /////////////////////
 
 
 
-#endif	/*XTP_MULTIARRAY__H */
+#endif	// VOTCA_XTP_MULTIARRAY_H
 

--- a/include/votca/xtp/nbo.h
+++ b/include/votca/xtp/nbo.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_NBO__H
-#define	__VOTCA_XTP_NBO__H
+#ifndef VOTCA_XTP_NBO_H
+#define	VOTCA_XTP_NBO_H
 
 
 #include <votca/tools/elements.h>
@@ -56,6 +56,6 @@ private:
 };
 }}
 
-#endif /* __VOTCA_XTP_NBO_H */
+#endif // VOTCA_XTP_NBO_H 
 
 

--- a/include/votca/xtp/numerical_integrations.h
+++ b/include/votca/xtp/numerical_integrations.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_NUMERICAL_INTEGRATION__H
-#define	__XTP_NUMERICAL_INTEGRATION__H
+#ifndef XTP_NUMERICAL_INTEGRATION_H
+#define	XTP_NUMERICAL_INTEGRATION_H
 
 
 
@@ -115,4 +115,4 @@ namespace votca { namespace xtp {
         };
 
     }}
-#endif	/* NUMERICAL_INTEGRATION_H */
+#endif	// XTP_NUMERICAL_INTEGRATION_H

--- a/include/votca/xtp/optimiser_costfunction.h
+++ b/include/votca/xtp/optimiser_costfunction.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_OPTIMISER_COSTFUNCTION__H
-#define __XTP_OPTIMISER_COSTFUNCTION__H
+#ifndef VOTCA_XTP_OPTIMISER_COSTFUNCTION_H
+#define VOTCA_XTP_OPTIMISER_COSTFUNCTION_H
 
 #include <votca/xtp/eigen.h>
 
@@ -43,4 +43,4 @@ namespace votca {
 
     }
 }
-#endif /* FORCES_H */
+#endif // VOTCA_XTP_OPTIMISER_COSTFUNCTION_H

--- a/include/votca/xtp/orbitals.h
+++ b/include/votca/xtp/orbitals.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_ORBITALS_H
-#define __VOTCA_XTP_ORBITALS_H
+#ifndef VOTCA_XTP_ORBITALS_H
+#define VOTCA_XTP_ORBITALS_H
 
 #include <votca/xtp/eigen.h>
 
@@ -695,4 +695,4 @@ namespace votca {
 }
 
 
-#endif /* __VOTCA_XTP_ORBITALS_H */
+#endif // VOTCA_XTP_ORBITALS_H 

--- a/include/votca/xtp/paircalculator.h
+++ b/include/votca/xtp/paircalculator.h
@@ -1,5 +1,5 @@
-#ifndef _PAIRCALCULATOR2_H
-#define	_PAIRCALCULATOR2_H
+#ifndef VOTCA_XTP_PAIRCALCULATOR2_H
+#define	VOTCA_XTP_PAIRCALCULATOR2_H
 
 #include <votca/xtp/qmcalculator.h>
 
@@ -46,6 +46,6 @@ bool PairCalculator2::EvaluateFrame(Topology *top) {
 
 }}
 
-#endif	/* _PAIRCALCULATOR2_H */
+#endif	// VOTCA_XTP_PAIRCALCULATOR2_H
 
  

--- a/include/votca/xtp/parallelpaircalc.h
+++ b/include/votca/xtp/parallelpaircalc.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_PARALLELPAIRCALC_H
-#define __VOTCA_XTP_PARALLELPAIRCALC_H
+#ifndef VOTCA_XTP_PARALLELPAIRCALC_H
+#define VOTCA_XTP_PARALLELPAIRCALC_H
 
 #include <votca/tools/thread.h>
 #include <votca/tools/mutex.h>
@@ -94,4 +94,4 @@ protected:
 
 }}
 
-#endif  // __VOTCA_XTP_PARALLELPAIRCALC_H
+#endif  // VOTCA_XTP_PARALLELPAIRCALC_H

--- a/include/votca/xtp/parallelxjobcalc.h
+++ b/include/votca/xtp/parallelxjobcalc.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_PARALLELXJOBCALC_H
-#define __VOTCA_XTP_PARALLELXJOBCALC_H
+#ifndef VOTCA_XTP_PARALLELXJOBCALC_H
+#define VOTCA_XTP_PARALLELXJOBCALC_H
 
 #include <votca/xtp/jobcalculator.h>
 #include <votca/xtp/qmthread.h>
@@ -109,4 +109,4 @@ protected:
 
 }}
 
-#endif // __VOTCA_XTP_PARALLELXJOBCALC_H
+#endif // VOTCA_XTP_PARALLELXJOBCALC_H

--- a/include/votca/xtp/pewald3d.h
+++ b/include/votca/xtp/pewald3d.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_PEWALD3D_H
-#define __VOTCA_XTP_PEWALD3D_H
+#ifndef VOTCA_XTP_PEWALD3D_H
+#define VOTCA_XTP_PEWALD3D_H
 
 #include <votca/csg/boundarycondition.h>
 #include <votca/xtp/xjob.h>
@@ -88,5 +88,5 @@ namespace votca { namespace xtp {
 }}
 
 
-#endif // __VOTCA_XTP_PEWALD3D_H
+#endif // VOTCA_XTP_PEWALD3D_H
 

--- a/include/votca/xtp/poissongrid.h
+++ b/include/votca/xtp/poissongrid.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_POISSONGRID_H
-#define __VOTCA_XTP_POISSONGRID_H
+#ifndef VOTCA_XTP_POISSONGRID_H
+#define VOTCA_XTP_POISSONGRID_H
 
 #include <votca/tools/vec.h>
 
@@ -59,4 +59,4 @@ class PoissonCell
     
 }}}
 
-#endif // __VOTCA_XTP_POISSONGRID_H
+#endif // VOTCA_XTP_POISSONGRID_H

--- a/include/votca/xtp/polarfrag.h
+++ b/include/votca/xtp/polarfrag.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_POLARFRAG_H
-#define __VOTCA_XTP_POLARFRAG_H
+#ifndef VOTCA_XTP_POLARFRAG_H
+#define VOTCA_XTP_POLARFRAG_H
 
 #include <votca/xtp/apolarsite.h>
 #include <boost/serialization/vector.hpp>
@@ -81,4 +81,4 @@ private:
 
 }}
 
-#endif // __VOTCA_XTP_POLARFRAG_H
+#endif // VOTCA_XTP_POLARFRAG_H

--- a/include/votca/xtp/polarseg.h
+++ b/include/votca/xtp/polarseg.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_POLARSEG_H
-#define	__VOTCA_XTP_POLARSEG_H
+#ifndef VOTCA_XTP_POLARSEG_H
+#define	VOTCA_XTP_POLARSEG_H
 
 #include <votca/tools/vec.h>
 #include <votca/xtp/apolarsite.h>
@@ -127,4 +127,4 @@ private:
 
 }}
 
-#endif // __VOTCA_XTP_POLARSEG_H
+#endif // VOTCA_XTP_POLARSEG_H

--- a/include/votca/xtp/polartop.h
+++ b/include/votca/xtp/polartop.h
@@ -19,8 +19,8 @@
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
 
-#ifndef __VOTCA_XTP_POLARTOP_H
-#define	__VOTVA_XTP_POLARTOP_H
+#ifndef VOTCA_XTP_POLARTOP_H
+#define	VOTVA_XTP_POLARTOP_H
 
 #include <votca/xtp/polarseg.h>
 #include <votca/xtp/topology.h>
@@ -138,4 +138,4 @@ private:
 
 }}
 
-#endif // __VOTCA_XTP_POLARTOP_H
+#endif // VOTCA_XTP_POLARTOP_H

--- a/include/votca/xtp/ppm.h
+++ b/include/votca/xtp/ppm.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_PPM_H
-#define _VOTCA_XTP_PPM_H
+#ifndef VOTCA_XTP_PPM_H
+#define VOTCA_XTP_PPM_H
 #include <votca/xtp/eigen.h>
 #include <votca/xtp/rpa.h>
 
@@ -78,4 +78,4 @@ double getScreening_i()const{return screening_i;}
 }
 }
 
-#endif /* _VOTCA_XTP_GWBSE_H */
+#endif // VOTCA_XTP_GWBSE_H 

--- a/include/votca/xtp/progressobserver.h
+++ b/include/votca/xtp/progressobserver.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_PROGRESSOBSERVER_H
-#define __VOTCA_XTP_PROGRESSOBSERVER_H
+#ifndef VOTCA_XTP_PROGRESSOBSERVER_H
+#define VOTCA_XTP_PROGRESSOBSERVER_H
 
 #include <vector>
 #include <iostream>
@@ -111,5 +111,5 @@ void UPDATE_JOBS(JobContainer &from, JobContainer &to, std::string thisHost);
 }}
 
 
-#endif // __VOTCA_XTP_PROGRESSOBSERVER_H
+#endif // VOTCA_XTP_PROGRESSOBSERVER_H
 

--- a/include/votca/xtp/qmapemachine.h
+++ b/include/votca/xtp/qmapemachine.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __QMAPEMACHINE__H
-#define	__QMAPEMACHINE__H
+#ifndef VOTCA_XTP_QMAPEMACHINE_H
+#define	VOTCA_XTP_QMAPEMACHINE_H
 
 
 
@@ -99,4 +99,5 @@ private:
 
 }}
 
-#endif
+#endif // VOTCA_XTP_QMAPEMACHINE_H
+

--- a/include/votca/xtp/qmatom.h
+++ b/include/votca/xtp/qmatom.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_QMATOM_H
-#define	__VOTCA_XTP_QMATOM_H
+#ifndef VOTCA_XTP_QMATOM_H
+#define	VOTCA_XTP_QMATOM_H
 
 #include <votca/tools/vec.h> 
 #include <votca/xtp/checkpointwriter.h>
@@ -101,5 +101,5 @@ private:
     
 }}
 
-#endif	/* __VOTCA_XTP_QMATOM_H */
+#endif	// VOTCA_XTP_QMATOM_H 
 

--- a/include/votca/xtp/qmcalculator.h
+++ b/include/votca/xtp/qmcalculator.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_QMCALCULATOR_H
-#define __VOTCA_XTP_QMCALCULATOR_H
+#ifndef VOTCA_XTP_QMCALCULATOR_H
+#define VOTCA_XTP_QMCALCULATOR_H
 
 #include <votca/tools/calculator.h>
 
@@ -45,4 +45,4 @@ public:
 
 }}
 
-#endif // __VOTCA_XTP_QMCALCULATOR_H 
+#endif // VOTCA_XTP_QMCALCULATOR_H 

--- a/include/votca/xtp/qmdatabase.h
+++ b/include/votca/xtp/qmdatabase.h
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef __VOTCA_XTP_QMDATABASE2_H
-#define	__VOTCA_XTP_QMDATABASE2_H
+#ifndef VOTCA_XTP_QMDATABASE2_H
+#define	VOTCA_XTP_QMDATABASE2_H
 
 #include <votca/tools/database.h>
 
@@ -48,5 +48,6 @@ public:
 
 }}
 
-#endif	/* QMDATABASE2_H */
+#endif	// VOTCA_XTP_QMDATABASE2_H
+
 

--- a/include/votca/xtp/qminterface.h
+++ b/include/votca/xtp/qminterface.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_QMMINTERFACE__H
-#define	__VOTCA_XTP_QMMINTERFACE__H
+#ifndef VOTCA_XTP_QMMINTERFACE_H
+#define	VOTCA_XTP_QMMINTERFACE_H
 
 #include <votca/tools/elements.h>
 
@@ -64,4 +64,4 @@ private:
 
 }}
 
-#endif
+#endif // VOTCA_XTP_QMMINTERFACE_H

--- a/include/votca/xtp/qmiter.h
+++ b/include/votca/xtp/qmiter.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __QMITER__H
-#define	__QMITER__H
+#ifndef VOTCA_XTP_QMITER_H
+#define	VOTCA_XTP_QMITER_H
 
 namespace votca { namespace xtp {
 
@@ -85,4 +85,4 @@ private:
     
 }}
 
-#endif
+#endif // VOTCA_XTP_QMITER_H

--- a/include/votca/xtp/qmmachine.h
+++ b/include/votca/xtp/qmmachine.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __QMMACHINE__H
-#define	__QMMACHINE__H
+#ifndef VOTCA_XTP_QMMACHINE_H
+#define	VOTCA_XTP_QMMACHINE_H
 
 #include <votca/xtp/xjob.h>
 #include <votca/xtp/xinductor.h>
@@ -91,4 +91,5 @@ private:
 
 }}
 
-#endif
+#endif //  VOTCA_XTP_QMMACHINE_H
+

--- a/include/votca/xtp/qmnblist.h
+++ b/include/votca/xtp/qmnblist.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef _VOTCA_XTP_QMNBList_H
-#define	_VOTCA_XTP_QMNBList_H
+#ifndef VOTCA_XTP_QMNBList_H
+#define	VOTCA_XTP_QMNBList_H
 
 #include <string>
 #include <vector>
@@ -149,5 +149,5 @@ protected:
 }}
 
 
-#endif	/* _VOTCA_XTP_QMNBLIST_H */
+#endif	// VOTCA_XTP_QMNBLIST_H 
 

--- a/include/votca/xtp/qmpackage.h
+++ b/include/votca/xtp/qmpackage.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _XTP_QM_PACKAGE_H
-#define _XTP_QM_PACKAGE_H
+#ifndef VOTCA_XTP_QM_PACKAGE_H
+#define VOTCA_XTP_QM_PACKAGE_H
 
 #include <votca/xtp/logger.h>
 #include <votca/xtp/orbitals.h>
@@ -186,4 +186,5 @@ namespace votca {
     }
 }
 
-#endif /* _XTP_QM_PACKAGE_H */
+#endif // VOTCA_XTP_QM_PACKAGE_H
+

--- a/include/votca/xtp/qmpackagefactory.h
+++ b/include/votca/xtp/qmpackagefactory.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __QMPACKAGEFACTORY__H
-#define	__QMPACKAGEFACTORY__H
+#ifndef VOTCA_XTP_QMPACKAGEFACTORY_H
+#define	VOTCA_XTP_QMPACKAGEFACTORY_H
 
 #include <votca/tools/objectfactory.h>
 #include <votca/xtp/qmpackage.h>
@@ -48,5 +48,5 @@ inline QMPackageFactory &QMPackages()
 
 }}
 
-#endif	/* __QMPACKAGEFACTORY__H */
+#endif	// VOTCA_XTP_QMPACKAGEFACTORY_H 
 

--- a/include/votca/xtp/qmpair.h
+++ b/include/votca/xtp/qmpair.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef _VOTCA_XTP_QMPAIR_H
-#define _VOTCA_XTP_QMPAIR_H
+#ifndef VOTCA_XTP_QMPAIR_H
+#define VOTCA_XTP_QMPAIR_H
 
 #include <vector>
 #include <votca/tools/vec.h>
@@ -169,4 +169,4 @@ protected:
 }}
 
 
-#endif // _VOTCA_XTP_QMPAIR_H
+#endif // VOTCA_XTP_QMPAIR_H

--- a/include/votca/xtp/qmstate.h
+++ b/include/votca/xtp/qmstate.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_QMSTATE_H
-#define _VOTCA_XTP_QMSTATE_H
+#ifndef VOTCA_XTP_QMSTATE_H
+#define VOTCA_XTP_QMSTATE_H
 
 #include<string>
 
@@ -132,4 +132,4 @@ private:
 }
 }
 
-#endif /* _VOTCA_XTP_QMSTATE_H */
+#endif // VOTCA_XTP_QMSTATE_H 

--- a/include/votca/xtp/qmthread.h
+++ b/include/votca/xtp/qmthread.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_QMTHREAD_H
-#define	__VOTCA_XTP_QMTHREAD_H
+#ifndef VOTCA_XTP_QMTHREAD_H
+#define	VOTCA_XTP_QMTHREAD_H
 
 #include "votca/tools/thread.h"
 #include "votca/tools/globals.h"
@@ -62,4 +62,4 @@ namespace votca { namespace xtp {
 
 }}
 
-#endif // __VOTCA_XTP_QMTHREAD_H
+#endif // VOTCA_XTP_QMTHREAD_H

--- a/include/votca/xtp/qmtool.h
+++ b/include/votca/xtp/qmtool.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_QMTOOL_H
-#define __VOTCA_XTP_QMTOOL_H
+#ifndef VOTCA_XTP_QMTOOL_H
+#define VOTCA_XTP_QMTOOL_H
 
 #include <votca/tools/property.h>
 #include <votca/xtp/qmcalculator.h>
@@ -48,4 +48,4 @@ private:
 
 }}
 
-#endif // __VOTCA_XTP_QMTOOL_H 
+#endif // VOTCA_XTP_QMTOOL_H 

--- a/include/votca/xtp/radial_euler_maclaurin_rule.h
+++ b/include/votca/xtp/radial_euler_maclaurin_rule.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_EULER_MACLAURIN__H
-#define	__XTP_EULER_MACLAURIN__H
+#ifndef VOTCA_XTP_EULER_MACLAURIN_H
+#define	VOTCA_XTP_EULER_MACLAURIN_H
 
 
 #include <votca/xtp/basisset.h>
@@ -477,4 +477,5 @@ c                  Md   No   Lr  Unq  Unp
         };
 
     }}
-#endif	/* EULER_MACLAURIN_H */
+#endif	// VOTCA_XTP_EULER_MACLAURIN_H
+

--- a/include/votca/xtp/rpa.h
+++ b/include/votca/xtp/rpa.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_RPA_H
-#define _VOTCA_XTP_RPA_H
+#ifndef VOTCA_XTP_RPA_H
+#define VOTCA_XTP_RPA_H
 #include <votca/xtp/eigen.h>
 #include <vector>
 
@@ -97,4 +97,4 @@ namespace votca {
     }
 }
 
-#endif /* _VOTCA_RPA_RPA_H */
+#endif // VOTCA_RPA_RPA_H 

--- a/include/votca/xtp/segment.h
+++ b/include/votca/xtp/segment.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_SEGMENT_H
-#define	__VOTCA_XTP_SEGMENT_H
+#ifndef VOTCA_XTP_SEGMENT_H
+#define	VOTCA_XTP_SEGMENT_H
 
 #include <map>
 #include <vector>
@@ -188,5 +188,5 @@ private:
 
 }}
 
-#endif	/* __VOTCA_XTP_SEGMENT_H */
+#endif	// VOTCA_XTP_SEGMENT_H 
 

--- a/include/votca/xtp/segmenttype.h
+++ b/include/votca/xtp/segmenttype.h
@@ -18,8 +18,8 @@
  */
 /// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_SEGMENT_TYPE_H
-#define	__VOTCA_XTP_SEGMENT_TYPE_H
+#ifndef VOTCA_XTP_SEGMENT_TYPE_H
+#define	VOTCA_XTP_SEGMENT_TYPE_H
 
 #include <string>
 
@@ -79,5 +79,5 @@ private:
 
 }}
 
-#endif	/* __VOTCA_XTP_SEGMENT_TYPE_H */
+#endif	// VOTCA_XTP_SEGMENT_TYPE_H 
 

--- a/include/votca/xtp/sigma.h
+++ b/include/votca/xtp/sigma.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_SIGMA_H
-#define _VOTCA_XTP_SIGMA_H
+#ifndef VOTCA_XTP_SIGMA_H
+#define VOTCA_XTP_SIGMA_H
 #include <votca/xtp/eigen.h>
 #include <votca/xtp/logger.h>
 
@@ -106,4 +106,4 @@ const Eigen::VectorXd* _dftenergies;
 }
 }
 
-#endif /* _VOTCA_XTP_SIGMA_H */
+#endif // VOTCA_XTP_SIGMA_H 

--- a/include/votca/xtp/sphere_lebedev_rule.h
+++ b/include/votca/xtp/sphere_lebedev_rule.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_LEBEDEV__H
-#define	__XTP_LEBEDEV__H
+#ifndef VOTCA_XTP_LEBEDEV_H
+#define	VOTCA_XTP_LEBEDEV_H
 
 
 #include <votca/tools/property.h>
@@ -418,4 +418,4 @@ namespace votca {
 
     }
 }
-#endif	/* LEBEDEV_H */
+#endif	// VOTCA_XTP_LEBEDEV_H

--- a/include/votca/xtp/sqlapplication.h
+++ b/include/votca/xtp/sqlapplication.h
@@ -72,7 +72,7 @@ protected:
 
 
 
-#endif /* _QMApplication_H */
+#endif // VOTCA_XTP_SQLAPPLICATION_H
 
 
 

--- a/include/votca/xtp/statefilter.h
+++ b/include/votca/xtp/statefilter.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_STATEFILTER_H
-#define _VOTCA_XTP_STATEFILTER_H
+#ifndef VOTCA_XTP_STATEFILTER_H
+#define VOTCA_XTP_STATEFILTER_H
 
 #include <votca/xtp/orbitals.h>
 #include <votca/xtp/logger.h>
@@ -87,4 +87,4 @@ double _dQ_threshold;
 }
 }
 
-#endif /* _VOTCA_XTP_STATEFILTER_H */
+#endif // VOTCA_XTP_STATEFILTER_H 

--- a/include/votca/xtp/statesaversqlite.h
+++ b/include/votca/xtp/statesaversqlite.h
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef __VOTCA_MD2QM_StateSaverSQLite_H
-#define	__VOTCA_MD2QM_StateSaverSQLite_H
+#ifndef VOTCA_MD2QM_STATE_SAVER_SQLITE_H
+#define	VOTCA_MD2QM_STATE_SAVER_SQLITE_H
 
 #include <stdio.h>
 #include <map>
@@ -85,5 +85,5 @@ private:
 
 }}
 
-#endif	/* __VOTCA_MD2QM_StateSaverSQLite2_H */
+#endif	// VOTCA_MD2QM_STATE_SAVER_SQLITE_H
 

--- a/include/votca/xtp/symmetric_matrix.h
+++ b/include/votca/xtp/symmetric_matrix.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_SYMMETRIC_MATRIX__H
-#define	__XTP_SYMMETRIC_MATRIX__H
+#ifndef VOTCA_XTP_SYMMETRIC_MATRIX_H
+#define	VOTCA_XTP_SYMMETRIC_MATRIX_H
 
 
 
@@ -83,5 +83,5 @@ private:
  
 }}
 
-#endif	/* AOBASIS_H */
+#endif	// VOTCA_XTP_SYMMETRIC_MATRIX_H
 

--- a/include/votca/xtp/threecenter.h
+++ b/include/votca/xtp/threecenter.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __XTP_THREECENTER__H
-#define	__XTP_THREECENTER__H
+#ifndef VOTCA_XTP_THREECENTER_H
+#define	VOTCA_XTP_THREECENTER_H
 
 
 
@@ -155,5 +155,5 @@ namespace votca {
 
 }}
 
-#endif	/* AOMATRIX_H */
+#endif	// VOTCA_XTP_THREECENTER_H
 

--- a/include/votca/xtp/toolfactory.h
+++ b/include/votca/xtp/toolfactory.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_QMTOOLFACTORY__H
-#define	__VOTCA_XTP_QMTOOLFACTORY__H
+#ifndef VOTCA_XTP_QMTOOLFACTORY_H
+#define	VOTCA_XTP_QMTOOLFACTORY_H
 
 #include <votca/tools/objectfactory.h>
 #include <votca/xtp/qmtool.h>
@@ -46,5 +46,5 @@ inline QMToolFactory &QMTools()
 
 }}
 
-#endif	/* __VOTCA_XTP_QMTOOLFACTORY__H */
+#endif	// VOTCA_XTP_QMTOOLFACTORY_H 
 

--- a/include/votca/xtp/topology.h
+++ b/include/votca/xtp/topology.h
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef __VOTCA_XTP_TOPOLOGY_H
-#define	__VOTCA_XTP_TOPOLOGY_H
+#ifndef VOTCA_XTP_TOPOLOGY_H
+#define	VOTCA_XTP_TOPOLOGY_H
 
 #include <vector>
 #include <string>
@@ -139,5 +139,5 @@ protected:
 
 }}
 
-#endif	/* __VOTCA_XTP_TOPOLOGY_H */
+#endif	// VOTCA_XTP_TOPOLOGY_H 
 

--- a/include/votca/xtp/version.h
+++ b/include/votca/xtp/version.h
@@ -15,8 +15,8 @@
  *
  */
 
-#ifndef __VOTCA_MD2QM_VERSION_H
-#define	__VOTCA_MD2QM_VERSION_H
+#ifndef VOTCA_MD2QM_VERSION_H
+#define	VOTCA_MD2QM_VERSION_H
 
 #include <string>
 /**
@@ -30,5 +30,6 @@ namespace votca { namespace xtp {
     void HelpTextHeader(const std::string &tool_name);
 }}
 
-#endif
+#endif //  VOTCA_MD2QM_VERSION_H
+
 

--- a/include/votca/xtp/votca_config.h.in
+++ b/include/votca/xtp/votca_config.h.in
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef _VOTCA_XTP_CONFIG_H
-#define _VOTCA_XTP_CONFIG_H
+#ifndef VOTCA_XTP_CONFIG_H
+#define VOTCA_XTP_CONFIG_H
 
 /* OpenMP */
 
@@ -37,4 +37,4 @@
 
 
 
-#endif // _VOTCA_XTP_CONFIG_H
+#endif // VOTCA_XTP_CONFIG_H

--- a/include/votca/xtp/vxc_functionals.h
+++ b/include/votca/xtp/vxc_functionals.h
@@ -17,8 +17,8 @@
  *
  */
 
-#ifndef __VOTCA_XTP_VXCFUNCTIONALS_H
-#define	__VOTCA_XTP_VXCFUNCTIONALS_H
+#ifndef VOTCA_XTP_VXCFUNCTIONALS_H
+#define	VOTCA_XTP_VXCFUNCTIONALS_H
 
 #include <string>
 #include <map>
@@ -396,5 +396,5 @@ private:
 
 }}
 
-#endif	/* __VOTCA_XTP_ATOM_H */
+#endif	// VOTCA_XTP_VXCFUNCTIONALS_H
 

--- a/include/votca/xtp/xinductor.h
+++ b/include/votca/xtp/xinductor.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_XINDUCTOR_H
-#define	__VOTCA_XTP_XINDUCTOR_H
+#ifndef VOTCA_XTP_XINDUCTOR_H
+#define	VOTCA_XTP_XINDUCTOR_H
 
 #include <votca/xtp/topology.h>
 #include <votca/xtp/polarseg.h>
@@ -529,5 +529,5 @@ private:
 }}
 
 
-#endif // __VOTCA_XTP_XINDUCTOR_H
+#endif // VOTCA_XTP_XINDUCTOR_H
 

--- a/include/votca/xtp/xinteractor.h
+++ b/include/votca/xtp/xinteractor.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_XINTERACTOR_H
-#define	__VOTCA_XTP_XINTERACTOR_H
+#ifndef VOTCA_XTP_XINTERACTOR_H
+#define	VOTCA_XTP_XINTERACTOR_H
 
 #include <math.h>
 #include <votca/tools/vec.h>
@@ -3277,6 +3277,6 @@ inline void XInteractor::RevBias() {
 
 }}
 
-#endif // __VOTCA_XTP_XINTERACTOR_H
+#endif // VOTCA_XTP_XINTERACTOR_H
 
 

--- a/include/votca/xtp/xjob.h
+++ b/include/votca/xtp/xjob.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_XJOB_H
-#define	__VOTCA_XTP_XJOB_H
+#ifndef VOTCA_XTP_XJOB_H
+#define	VOTCA_XTP_XJOB_H
 
 #include <votca/xtp/topology.h>
 #include <votca/xtp/job.h>
@@ -238,5 +238,5 @@ JobContainer XJOBS_FROM_TABLE(const std::string &job_file, Topology *top);
     
 }}
 
-#endif // __VOTCA_XTP_XJOB_H
+#endif // VOTCA_XTP_XJOB_H
 

--- a/include/votca/xtp/xmapper.h
+++ b/include/votca/xtp/xmapper.h
@@ -18,8 +18,8 @@
  */
 /// For an earlier history see ctp repo commit 77795ea591b29e664153f9404c8655ba28dc14e9
 
-#ifndef __VOTCA_XTP_XMAPPER_H
-#define	__VOTCA_XTP_XMAPPER_H
+#ifndef VOTCA_XTP_XMAPPER_H
+#define	VOTCA_XTP_XMAPPER_H
 
 #include <votca/tools/mutex.h>
 #include <votca/xtp/xjob.h>
@@ -94,5 +94,5 @@ private:
 }}
 
 
-#endif // __VOTCA_XTP_XMAPPER_H
+#endif // VOTCA_XTP_XMAPPER_H
 

--- a/include/votca/xtp/xtpapplication.h
+++ b/include/votca/xtp/xtpapplication.h
@@ -55,7 +55,7 @@ protected:
 
 
 
-#endif /* _QMApplication_H */
+#endif // VOTCA_XTP_XTPAPPLICATION_H
 
 
 


### PR DESCRIPTION
I made all the header guards follow the following syntax for consistency
```
#ifndef VOTCA_XTP_NAME_H
#define VOTCA_XTP_NAME_H
#endif // VOTCA_XTP_NAME_H
```

