### PR TITLE
Output of dipoles for states

### DIFF
--- a/include/votca/xtp/aobasis.h
+++ b/include/votca/xtp/aobasis.h
@@ -48,8 +48,8 @@ public:
        
     void ReorderMatrix(Eigen::MatrixXd &v,const std::string& start,const std::string& target );
 
-    void AOBasisFill( const BasisSet& bs , std::vector<QMAtom* >& segments, int fragbreak = -1);
-    void ECPFill( const BasisSet& bs , std::vector<QMAtom* >& segments); 
+    void AOBasisFill( const BasisSet& bs , std::vector<QMAtom* >& atoms, int fragbreak = -1);
+    void ECPFill( const BasisSet& bs , std::vector<QMAtom* >& atoms); 
     
     int AOBasisSize() const {return _AOBasisSize; }
     

--- a/include/votca/xtp/aomatrix.h
+++ b/include/votca/xtp/aomatrix.h
@@ -70,8 +70,8 @@ namespace votca { namespace xtp {
     class AOMatrix : public AOSuperMatrix {
     public: 
 	// Access functions
-	int Dimension(){ return  _aomatrix.rows();};
-        const  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &Matrix() const{ return _aomatrix ;};       
+	int Dimension(){ return  _aomatrix.rows();}
+        const  Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> &Matrix() const{ return _aomatrix ;}      
         void Fill(const AOBasis& aobasis);
         void Print( std::string ident);
         void FreeMatrix(){
@@ -80,7 +80,7 @@ namespace votca { namespace xtp {
         // integrate F
         static std::vector<double> XIntegrate( int size, double U );
     protected:
-        virtual void FillBlock(Eigen::Block< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >&matrix,const  AOShell* shell_row,const AOShell* shell_col) {} ;
+        virtual void FillBlock(Eigen::Block< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> >&matrix,const  AOShell* shell_row,const AOShell* shell_col)=0 ;
         Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> _aomatrix;   
     };
     
@@ -91,14 +91,14 @@ namespace votca { namespace xtp {
      */
     class AOMatrix3D : public AOSuperMatrix {
     public:
-        const std::vector<Eigen::MatrixXd > &Matrix() const{ return _aomatrix ;};
+        const std::vector<Eigen::MatrixXd > &Matrix() const{ return _aomatrix ;}
         void Print( std::string _ident);
         void Fill(const AOBasis& aobasis );
         // block fill prototype
         void FreeMatrix();
     protected:
         std::vector<Eigen::MatrixXd > _aomatrix; 
-        virtual void FillBlock(std::vector<Eigen::Block<Eigen::MatrixXd> >& matrix,const AOShell* shell_row,const AOShell* shell_col) {} ;
+        virtual void FillBlock(std::vector<Eigen::Block<Eigen::MatrixXd> >& matrix,const AOShell* shell_row,const AOShell* shell_col)=0 ;
     };
     
     
@@ -115,8 +115,12 @@ namespace votca { namespace xtp {
      * electical transition dipoles
      */
     class AODipole : public AOMatrix3D { 
+    public:
+        void setCenter(const tools::vec& r){ _r=r;}// definition of a center around which the moment should be calculated
     protected:   
         void FillBlock(std::vector< Eigen::Block<Eigen::MatrixXd> >& matrix,const AOShell* shell_row,const AOShell* shell_col);
+    private:
+        tools::vec _r=tools::vec(0.0);
     };
     
     // derived class for atomic orbital nuclear potential

--- a/include/votca/xtp/dftengine.h
+++ b/include/votca/xtp/dftengine.h
@@ -94,7 +94,7 @@ namespace votca {
             
             Eigen::MatrixXd OrthogonalizeGuess(const Eigen::MatrixXd& GuessMOs );
             void PrintMOs(const Eigen::VectorXd& MOEnergies);
-            void CalcElDipole();
+            void CalcElDipole(Orbitals& orbitals)const;
             void CalculateERIs(const AOBasis& dftbasis, const Eigen::MatrixXd &DMAT);
             void ConfigOrbfile(Orbitals& orbitals);
             void SetupInvariantMatrices();

--- a/include/votca/xtp/esp2multipole.h
+++ b/include/votca/xtp/esp2multipole.h
@@ -50,10 +50,14 @@ public:
     
    
     void Extractingcharges( Orbitals& orbitals );
+ 
+
     void WritetoFile(std::string output_file);
     std::string GetStateString()const{return _state.ToString();}
 
 private:
+    
+       void PrintDipoles(Orbitals& orbitals);
     
     QMState      _state;  
     int         _openmp_threads;
@@ -65,7 +69,7 @@ private:
     bool        _use_CHELPG;
     bool        _do_svd;
     double      _conditionnumber;
-    std::vector< QMAtom* > _Atomlist;
+    std::vector< QMAtom* > _atomlist;
     
     ctp::Logger*      _log;
     std::vector< std::pair<int,int> > _pairconstraint; //  pairconstraint[i] is all the atomindices which have the same charge     

--- a/include/votca/xtp/orbitals.h
+++ b/include/votca/xtp/orbitals.h
@@ -34,6 +34,8 @@
 #include <votca/tools/constants.h>
 #include <votca/xtp/qmstate.h>
 
+#include "basisset.h"
+
 
 namespace votca {
     namespace xtp {
@@ -308,18 +310,18 @@ namespace votca {
 
             // access to list of indices used in BSE
 
-            void setBSEtype(std::string bsetype){_bsetype=bsetype;}
-            const std::string& getBSEtype() const{return _bsetype;}
+            void setTDAApprox(bool usedTDA){_useTDA=usedTDA;}
+            bool getTDAApprox() const{return _useTDA;}
 
 
             bool hasBSEindices() const{
                 return ( _bse_cmax > 0) ? true : false;
             }
 
-            void setBSEindices(int vmin, int vmax, int cmin, int cmax, int nmax) {
+            void setBSEindices(int vmin, int cmax, int nmax){
                 _bse_vmin = vmin;
-                _bse_vmax = vmax;
-                _bse_cmin = cmin;
+                _bse_vmax = this->getHomo();
+                _bse_cmin = this->getLumo();
                 _bse_cmax = cmax;
                 _bse_nmax = nmax;
                 _bse_vtotal = _bse_vmax - _bse_vmin + 1;
@@ -485,6 +487,8 @@ namespace votca {
             }
 
             std::vector<double> Oscillatorstrengths()const;
+            
+            Eigen::Vector3d CalcElDipole(const QMState& state);
         
             //Calculates full electron density for state or transition density, if you want to calculate only the density contribution of hole or electron use DensityMatrixExcitedState
             Eigen::MatrixXd DensityMatrixFull(const QMState& state)const;
@@ -622,7 +626,7 @@ namespace votca {
             int _unoccupied_levels;
             int _number_of_electrons;
             std::string _ECP;
-            std::string _bsetype;
+            bool _useTDA;
 
 
             Eigen::VectorXd _mo_energies;

--- a/netbeans/libxtp/nbproject/configurations.xml
+++ b/netbeans/libxtp/nbproject/configurations.xml
@@ -265,7 +265,6 @@
       <itemPath>../../src/tests/test_fragment.cc</itemPath>
       <itemPath>../../src/tests/test_glink.cc</itemPath>
       <itemPath>../../src/tests/test_hdf5.cc</itemPath>
-      <itemPath>../../src/tests/test_linalg_xtp.cc</itemPath>
       <itemPath>../../src/tests/test_molecule.cc</itemPath>
       <itemPath>../../src/tests/test_numericalintegration.cc</itemPath>
       <itemPath>../../src/tests/test_orbitals.cc</itemPath>

--- a/share/xtp/xml/kmcmultiple.xml
+++ b/share/xtp/xml/kmcmultiple.xml
@@ -9,15 +9,9 @@
 	    <injection help="Name pattern that specifies on which sites injection is possible. Before injecting on a site it is checked whether the column 'name' in the table 'segments' of the state file matches this pattern. Use the wildcard '*' to inject on any site." unit="" default="*">*</injection>
 	    <injectionmethod help="Options: random/equilibrated. random: injection sites are selected randomly (generally the recommended option); equilibrated: sites are chosen such that the expected energy per carrier is matched, possibly speeding up convergence" unit="" default="random">random</injectionmethod>
 	    <numberofcharges help="Number of electrons/holes in the simulation box" unit="integer" default="1">1</numberofcharges>
-	    <fieldX help="x component of the external electric field" unit="V/m" default="0">0</fieldX>
-	    <fieldY help="y component of the external electric field" unit="V/m" default="0">0</fieldY>
-	    <fieldZ help="z component of the external electric field" unit="V/m" default="1E6">1E6</fieldZ>
+	    <field help="external electric field" unit="V/m" default="0">0 0 1e6</field>
 	    <carriertype help="Options: electron/hole/singlet/triplet. Specifies the carrier type of the transport under consideration." unit="" default="electron">electron</carriertype>
 	    <temperature help="Temperature in Kelvin. Will only be relevant if rates are calculated by KMC and not taken from the state file." unit="Kelvin" default="300">300</temperature>
-	    <!-- 0=no explit Coulomb interaction;
-            	1=explicit Coulomb interaction using partial charges from SQL file
-		    2=explicit "raw" Coulomb interaction using charges of +/-1. -->
-	    <explicitcoulomb help="Options: 0/1/2. 0: no explit Coulomb interaction; 1: explicit Coulomb interaction using partial charges from SQL file, 2: explicit 'raw' Coulomb interaction using charges of +/-1. Note that rates from the state file will not be used if Coulomb interaction is switched on (option 1 or 2) but rates will be calculated within KMC." unit="" default="0">0</explicitcoulomb>
 	    <rates help="Options: statefile/calculate. statefile: use the rates for charge transfer specified in the state file; calculate: use transfer integrals, site energies and reorganisation energies specified in the state file as well as temperature and electric field specified here to calculate rates before starting the KMC simulation. In case of explicit Coulomb interaction this option is set to 'calculate' automatically. If you use rates from the state file make sure that the electric field specified here matches the one that was used for calculating the rates in the state file." unit="" default="statefile">statefile</rates>
     </kmcmultiple>
 

--- a/src/libxtp/aobasis.cc
+++ b/src/libxtp/aobasis.cc
@@ -504,7 +504,7 @@ std::vector<int> AOBasis::invertOrder(const std::vector<int>& order ){
       for (QMAtom* atom : atoms) {
         int atomfunc=0;
         const std::string& name = atom->getType();
-        atom->_nuccharge = elementinfo.getNucCrg(name);
+        atom->_nuccharge = elementinfo.getNucCrg(name);//TODO remove this 
         const Element& element = bs.getElement(name);
         for (const Shell& shell:element) {
           int numfuncshell = NumFuncShell(shell.getType());

--- a/src/libxtp/aomatrices/aodipole.cc
+++ b/src/libxtp/aomatrices/aodipole.cc
@@ -108,13 +108,7 @@ namespace votca { namespace xtp {
                      0,  0,  4,  0,  5,  6,  0,  7,  8,  9,
                      0,  0, 10,  0, 11, 12,  0, 13, 14, 15,  0, 16, 17, 18, 19 };
 
-
-
-        // some helpers
        
-        // definition of a center around which the moment should be calculated
-        tools::vec center(0.0); // here: origin, can be changed later
-        tools::vec pmc(0.0);
         
         
         // iterate over Gaussians in this shell_row
@@ -144,7 +138,7 @@ namespace votca { namespace xtp {
         const double PmB2 = fak2*( decay_row * pos_row.getZ() + decay_col * pos_col.getZ() ) - pos_col.getZ();        
         
         
-        pmc= fak2*(decay_row * pos_row + decay_col * pos_col)-center;
+        tools::vec pmc= fak2*(decay_row * pos_row + decay_col * pos_col)-_r;
    
         // calculate s-s- overlap matrix element
         ol(0,0) = pow(4.0*decay_row*decay_col,0.75) * pow(fak2,1.5)*exp(-fak2 * decay_row * decay_col *distsq); // s-s element

--- a/src/libxtp/aomatrices/aomatrix.cc
+++ b/src/libxtp/aomatrices/aomatrix.cc
@@ -45,26 +45,20 @@ namespace votca {
             // loop row
 #pragma omp parallel for schedule(guided)
             for (unsigned row = 0; row < aobasis.getNumofShells(); row++) {
-
                 const AOShell* shell_row = aobasis.getShell(row);
                 int row_start = shell_row->getStartIndex();
-      
 
                 // AOMatrix is symmetric, restrict explicit calculation to triangular matrix
                 for (unsigned col = row; col <  aobasis.getNumofShells(); col++) {
-
                     const AOShell* shell_col = aobasis.getShell(col);
-
                     // figure out the submatrix
                     int col_start = shell_col->getStartIndex();
                     Eigen::Block< Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic> > block=
                             _aomatrix.block(row_start,col_start, shell_row->getNumFunc(),shell_col->getNumFunc());
                     // Fill block
                     FillBlock(block, shell_row, shell_col);
-
                 }
             }
-
             // Fill whole matrix by copying
         for ( unsigned i=0; i < _aomatrix.rows(); i++){
                 for (unsigned j = 0; j < i; j++) {
@@ -85,10 +79,8 @@ namespace votca {
             // loop row
 #pragma omp parallel for
             for (unsigned row = 0; row < aobasis.getNumofShells(); row++) {
-
                 const AOShell* shell_row = aobasis.getShell(row);
                 int row_start = shell_row->getStartIndex();
-
                 // loop column
                 for (const AOShell* shell_col:aobasis) {
                     // figure out the submatrix
@@ -100,7 +92,6 @@ namespace votca {
                     }
                     // Fill block
                     FillBlock(submatrix, shell_row, shell_col);
-
                 }
             }
             return;

--- a/src/libxtp/esp2multipole.cc
+++ b/src/libxtp/esp2multipole.cc
@@ -111,10 +111,30 @@ namespace votca {
             std::string tag = "TOOL:" + Identify() + "_" + _state.ToString();
 
             QMInterface Converter;
-            ctp::PolarSeg result = Converter.Convert(_Atomlist);
+            ctp::PolarSeg result = Converter.Convert(_atomlist);
 
             result.WriteMPS(output_file, tag);
             return;
+        }
+
+        void Esp2multipole::PrintDipoles(Orbitals& orbitals){
+          Eigen::Vector3d CoM = Eigen::Vector3d::Zero();
+          
+          for (QMAtom* atom : _atomlist) {
+            CoM += atom->getPos().toEigen();
+          }
+          CoM /= double(_atomlist.size());
+          Eigen::Vector3d classical_dip = Eigen::Vector3d::Zero();
+          for (QMAtom* atom : _atomlist) {
+            classical_dip += (atom->getPos().toEigen() - CoM) * atom->getPartialcharge();
+          }
+          CTP_LOG(ctp::logDEBUG, *_log) << "El Dipole from fitted charges [e*bohr]:\n\t\t" 
+                  << boost::format(" dx = %1$+1.4f dy = %2$+1.4f dz = %3$+1.4f |d|^2 = %4$+1.4f")
+                  % classical_dip[0] % classical_dip[1] % classical_dip[2] % classical_dip.squaredNorm()<< flush;
+          Eigen::Vector3d qm_dip=orbitals.CalcElDipole(_state);
+          CTP_LOG(ctp::logDEBUG, *_log) << "El Dipole from exact qm density [e*bohr]:\n\t\t"   
+                  << boost::format(" dx = %1$+1.4f dy = %2$+1.4f dz = %3$+1.4f |d|^2 = %4$+1.4f")
+                  % qm_dip[0] % qm_dip[1] % qm_dip[2] % qm_dip.squaredNorm()<< flush;
         }
 
         void Esp2multipole::Extractingcharges(Orbitals & orbitals) {
@@ -125,20 +145,21 @@ namespace votca {
 #endif
             CTP_LOG(ctp::logDEBUG, *_log) << "===== Running on " << threads << " threads ===== " << flush;
 
-            _Atomlist = orbitals.QMAtoms();
+            _atomlist = orbitals.QMAtoms();
             BasisSet bs;
             bs.LoadBasisSet(orbitals.getDFTbasis());
             AOBasis basis;
-            basis.AOBasisFill(bs, _Atomlist);
+            basis.AOBasisFill(bs, _atomlist);
             Eigen::MatrixXd DMAT=orbitals.DensityMatrixFull(_state);
+            
 
             if (_use_mulliken) {
                 Mulliken mulliken;
-                mulliken.EvaluateMulliken(_Atomlist, DMAT, basis, _state.isTransition());
+                mulliken.EvaluateMulliken(_atomlist, DMAT, basis, _state.isTransition());
             }
             else if (_use_lowdin) {
                 Lowdin lowdin;
-                lowdin.EvaluateLowdin(_Atomlist, DMAT, basis, _state.isTransition());
+                lowdin.EvaluateLowdin(_atomlist, DMAT, basis, _state.isTransition());
             } else if (_use_CHELPG) {
                 Espfit esp = Espfit(_log);
                 if(_pairconstraint.size()>0){
@@ -152,9 +173,12 @@ namespace votca {
                     esp.setUseSVD(_conditionnumber);
                 }
                 if (_integrationmethod == "numeric") {
-                    esp.Fit2Density(_Atomlist, DMAT, basis, _gridsize);
-                } else if (_integrationmethod == "analytic") esp.Fit2Density_analytic(_Atomlist, DMAT, basis);
+                    esp.Fit2Density(_atomlist, DMAT, basis, _gridsize);
+                } else if (_integrationmethod == "analytic") esp.Fit2Density_analytic(_atomlist, DMAT, basis);
             } 
+
+            PrintDipoles(orbitals);
+            
         }
 
     }

--- a/src/libxtp/gwbse/bse.cc
+++ b/src/libxtp/gwbse/bse.cc
@@ -393,7 +393,7 @@ template <typename T>
       if(tools::globals::verbose){
         act = Analyze_eh_interaction(singlet);
       }
-      if(dftbasis.getAOBasisFragA()>0){
+      if(dftbasis.getAOBasisFragA() > 0 && dftbasis.getAOBasisFragB()>0){
         pop=FragmentPopulations(singlet,dftbasis);
         _orbitals.setFragmentChargesSingEXC(pop.Crgs);
         _orbitals.setFragment_E_localisation_singlet(pop.popE);
@@ -576,15 +576,15 @@ template <typename T>
     std::vector<tools::vec > BSE::CalcCoupledTransition_Dipoles(const AOBasis& dftbasis) {
     std::vector<Eigen::MatrixXd > interlevel_dipoles= CalcFreeTransition_Dipoles(dftbasis);
     std::vector<tools::vec > dipols;
-      double sqrt2 = sqrt(2.0);
+    const double sqrt2 = sqrt(2.0);
       for (int i_exc = 0; i_exc < _bse_nmax; i_exc++) {
         tools::vec tdipole = tools::vec(0, 0, 0);
         for (int c = 0; c < _bse_ctotal; c++) {
           for (int v = 0; v < _bse_vtotal; v++) {
             int index_vc = _bse_ctotal * v + c;
-            double factor = sqrt2 * _bse_singlet_coefficients(index_vc, i_exc);
+            double factor = _bse_singlet_coefficients(index_vc, i_exc);
             if (_bse_singlet_coefficients_AR.rows()>0) {
-              factor += sqrt2 * _bse_singlet_coefficients_AR(index_vc, i_exc);
+              factor += _bse_singlet_coefficients_AR(index_vc, i_exc);
             }
             // The Transition dipole is sqrt2 bigger because of the spin, the excited state is a linear combination of 2 slater determinants, where either alpha or beta spin electron is excited
             tdipole.x() += factor * interlevel_dipoles[0](v, c);
@@ -592,7 +592,8 @@ template <typename T>
             tdipole.z() += factor * interlevel_dipoles[2](v, c);
           }
         }
-        dipols.push_back(tdipole);     
+        
+        dipols.push_back(-sqrt2 *tdipole);     //- because electrons are negative
       }
       return dipols;
     }

--- a/src/libxtp/gwbse/gwbse.cc
+++ b/src/libxtp/gwbse/gwbse.cc
@@ -647,13 +647,13 @@ bool GWBSE::Evaluate() {
    // store information in _orbitals for later use
   _orbitals.setRPAindices(_rpamin, _rpamax);
   _orbitals.setGWAindices(_qpmin, _qpmax);
-  _orbitals.setBSEindices(_bse_vmin, _bse_vmax, _bse_cmin, _bse_cmax,
+  _orbitals.setBSEindices(_bse_vmin, _bse_cmax,
                            _bse_maxeigenvectors);
   
     if (_do_full_BSE)
-    _orbitals.setBSEtype("full");
+    _orbitals.setTDAApprox(false);
   else {
-    _orbitals.setBSEtype("TDA");
+    _orbitals.setTDAApprox(true);
   }
 
 

--- a/src/libxtp/orbitals.cc
+++ b/src/libxtp/orbitals.cc
@@ -19,6 +19,7 @@
 
 #include "votca/xtp/orbitals.h"
 #include "votca/xtp/qmstate.h"
+#include "votca/xtp/aomatrix.h"
 #include <votca/xtp/version.h>
 #include <votca/tools/elements.h>
 #include <votca/xtp/basisset.h>
@@ -45,7 +46,7 @@ namespace votca {
             _self_energy = 0.0;
             _qm_energy = 0.0;
             _ECP = "";
-            _bsetype = "";
+            _useTDA = false;
 
             // GW-BSE
             _qpmin = 0;
@@ -69,8 +70,7 @@ namespace votca {
         };
 
         Orbitals::~Orbitals() {
-            std::vector< QMAtom* >::iterator it;
-            for (it = _atoms.begin(); it != _atoms.end(); ++it) delete *it;
+            for (QMAtom* atom:_atoms) delete atom;
         };
 
         void Orbitals::setNumberOfLevels(int occupied_levels,int unoccupied_levels) {
@@ -187,6 +187,35 @@ namespace votca {
           }
           return result;
         }
+        
+        
+        Eigen::Vector3d Orbitals::CalcElDipole(const QMState& state) {
+          Eigen::Vector3d nuclei_dip = Eigen::Vector3d::Zero();
+          if (!state.isTransition()) {
+            Eigen::Vector3d CoM = Eigen::Vector3d::Zero();
+            for (QMAtom* atom : _atoms) {
+              CoM += atom->getPos().toEigen();
+            }
+            CoM /= double(_atoms.size());
+            for (QMAtom* atom : _atoms) {
+              nuclei_dip += (atom->getPos().toEigen() - CoM) * atom->getNuccharge();
+            }
+          }
+
+          BasisSet basis;
+          basis.LoadBasisSet(this->getDFTbasis());
+          AOBasis aobasis;
+          aobasis.AOBasisFill(basis, _atoms);
+          AODipole dipole;
+          dipole.Fill(aobasis);
+
+          Eigen::MatrixXd dmat = this->DensityMatrixFull(state);
+          Eigen::Vector3d electronic_dip;
+          for (int i = 0; i < 3; ++i) {
+            electronic_dip(i) = dmat.cwiseProduct(dipole.Matrix()[i]).sum();
+          }
+          return nuclei_dip - electronic_dip;
+        }
 
         Eigen::MatrixXd Orbitals::TransitionDensityMatrix(const QMState& state) const{
             if (state.Type() != QMStateType::Singlet) {
@@ -194,7 +223,7 @@ namespace votca {
             }
             const MatrixXfd& BSECoefs = _BSE_singlet_coefficients;
             if(BSECoefs.cols()<state.Index()+1 || BSECoefs.rows()<2){
-                throw runtime_error("Orbitals object has no information about that state");
+                throw runtime_error("Orbitals object has no information about state:"+state.ToString());
             }
             Eigen::MatrixXd dmatTS = Eigen::MatrixXd::Zero(_basis_set_size, _basis_set_size);
             // The Transition dipole is sqrt2 bigger because of the spin, the excited state is a linear combination of 2 slater determinants, where either alpha or beta spin electron is excited
@@ -206,15 +235,15 @@ namespace votca {
             // indexing info BSE vector index to occupied/virtual orbital
             Index2MO index=BSEIndex2MOIndex();
 
-            if (_bsetype == "full") {
-                const MatrixXfd& _BSECoefs_AR = _BSE_singlet_coefficients_AR;
+            if (!_useTDA) {
+                const MatrixXfd& BSECoefs_AR = _BSE_singlet_coefficients_AR;
 #pragma omp parallel for
                 for (int a = 0; a < dmatTS.rows(); a++) {
                     for (int b = 0; b < dmatTS.cols(); b++) {
                         for (int i = 0; i < _bse_size; i++) {
                             int occ = index.I2v[i];
                             int virt =index.I2c[i];
-                            dmatTS(a, b) += sqrt2 * (BSECoefs(i, state.Index()) + _BSECoefs_AR(i, state.Index())) * _mo_coefficients(a, occ) * _mo_coefficients(b, virt); //check factor 2??
+                            dmatTS(a, b) += sqrt2 * (BSECoefs(i, state.Index()) + BSECoefs_AR(i, state.Index())) * _mo_coefficients(a, occ) * _mo_coefficients(b, virt); //check factor 2??
                         }
                     }
                 }
@@ -237,7 +266,7 @@ namespace votca {
 
         std::vector<Eigen::MatrixXd > Orbitals::DensityMatrixExcitedState(const QMState& state) const{
             std::vector<Eigen::MatrixXd > dmat = DensityMatrixExcitedState_R(state);
-            if (_bsetype == "full" && state.Type() == QMStateType::Singlet) {
+            if (!_useTDA && state.Type() == QMStateType::Singlet) {
                 std::vector<Eigen::MatrixXd > dmat_AR = DensityMatrixExcitedState_AR(state);
                 dmat[0] -= dmat_AR[0];
                 dmat[1] -= dmat_AR[1];
@@ -254,7 +283,7 @@ namespace votca {
 
             const MatrixXfd & BSECoefs = (state.Type() == QMStateType::Singlet) ? _BSE_singlet_coefficients : _BSE_triplet_coefficients;
             if(BSECoefs.cols()<state.Index()+1 || BSECoefs.rows()<2){
-                throw runtime_error("Orbitals object has no information about that state");
+                throw runtime_error("Orbitals object has no information about state:"+state.ToString());
             }
             /******
              *
@@ -325,7 +354,7 @@ namespace votca {
             
             const MatrixXfd& BSECoefs_AR = _BSE_singlet_coefficients_AR;
             if(BSECoefs_AR.cols()<state.Index()+1 || BSECoefs_AR.rows()<2){
-                throw runtime_error("Orbitals object has no information about that state");
+                throw runtime_error("Orbitals object has no information about state:"+state.ToString());
             }
             /******
              *
@@ -649,7 +678,7 @@ namespace votca {
 
                 w(_ScaHFX, "ScaHFX");
 
-                w(_bsetype, "bsetype");
+                w(int(_useTDA), "useTDA");
                 w(_ECP, "ECP");
 
                 w(_QPpert_energies, "QPpert_energies");
@@ -736,8 +765,9 @@ namespace votca {
                 _bse_size = _bse_vtotal * _bse_ctotal;
 
                 r(_ScaHFX, "ScaHFX");
-
-                r(_bsetype, "bsetype");
+                int temp;
+                r(temp, "useTDA");
+                _useTDA=bool(temp);
                 r(_ECP, "ECP");
 
                 r(_QPpert_energies, "QPpert_energies");

--- a/src/tests/test_hdf5.cc
+++ b/src/tests/test_hdf5.cc
@@ -51,14 +51,11 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
     int rpaMax = 1e3;
 
     unsigned int bseVmin = -6019386;
-    unsigned int bseVmax = 1092581;
-
-    unsigned int bseCmin = 2718L;
     unsigned int bseCmax = 42;
 
     double scaHfx = 3.14159;
 
-    std::string bseType = "A+";
+    bool useTDA = true;
 
 
     Eigen::MatrixXd vxcTest = Eigen::MatrixXd::Random(200,200);
@@ -105,9 +102,9 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
         orbWrite.setAuxbasis(auxBasis);
         orbWrite.setRPAindices(rpaMin, rpaMax);
         // no need to write qpmin, qpmax
-        orbWrite.setBSEindices(bseVmin, bseVmax, bseCmin, bseCmax, 3);
+        orbWrite.setBSEindices(bseVmin, bseCmax, 3);
         orbWrite.setScaHFX(scaHfx);
-        orbWrite.setBSEtype(bseType);
+        orbWrite.setTDAApprox(useTDA);
         orbWrite.setECP(someECP);
         orbWrite.QPpertEnergies() = QPpertEnergiesTest;
         orbWrite.QPdiagEnergies() = QPdiagEnergiesTest;
@@ -144,12 +141,10 @@ BOOST_AUTO_TEST_CASE(checkpoint_file_test) {
     BOOST_CHECK_EQUAL(orbRead.getRPAmax(), rpaMax);
 
     BOOST_CHECK_EQUAL(orbRead.getBSEvmin(), bseVmin);
-    BOOST_CHECK_EQUAL(orbRead.getBSEvmax(), bseVmax);
-    BOOST_CHECK_EQUAL(orbRead.getBSEcmin(), bseCmin);
     BOOST_CHECK_EQUAL(orbRead.getBSEcmax(), bseCmax);
 
     BOOST_CHECK_CLOSE(orbRead.getScaHFX(), scaHfx, tol);
-    BOOST_CHECK_EQUAL(orbRead.getBSEtype(), bseType);
+    BOOST_CHECK_EQUAL(orbRead.getTDAApprox(), useTDA);
     BOOST_CHECK_EQUAL(orbRead.getECP(), someECP);
     BOOST_CHECK(orbRead.QPpertEnergies().isApprox(QPpertEnergiesTest, tol));
     BOOST_CHECK(orbRead.QPdiagEnergies().isApprox(QPdiagEnergiesTest, tol));

--- a/src/tests/test_orbitals.cc
+++ b/src/tests/test_orbitals.cc
@@ -36,7 +36,6 @@ BOOST_AUTO_TEST_CASE(readxyztest){
   xyzfile << " H           -.629118     .629118    -.629118" << std::endl;
   xyzfile.close();
   
-  
   bool errorhappen=false;
   Orbitals orb;
   try{
@@ -73,8 +72,6 @@ BOOST_AUTO_TEST_CASE(sortEnergies){
 
 BOOST_AUTO_TEST_CASE(densmatgs_test) {
   
-  
-  
   Orbitals orb;
   orb.setBasisSetSize(17);
   orb.setNumberOfLevels(4,13);
@@ -101,7 +98,7 @@ BOOST_AUTO_TEST_CASE(densmatgs_test) {
 Eigen::MatrixXd overlap_ref=Eigen::MatrixXd::Zero(17,17);
  
  std::ofstream xyzfile("molecule.xyz");
-  xyzfile << " C" << std::endl;
+  xyzfile << " 5" << std::endl;
   xyzfile << " methane" << std::endl;
   xyzfile << " C            .000000     .000000     .000000" << std::endl;
   xyzfile << " H            .629118     .629118     .629118" << std::endl;
@@ -202,6 +199,140 @@ Eigen::MatrixXd overlap_ref=Eigen::MatrixXd::Zero(17,17);
 BOOST_CHECK_EQUAL(check_dmat, 1);
 
 
+}
+
+
+BOOST_AUTO_TEST_CASE(dipole_test) {
+
+  
+  std::ofstream xyzfile("molecule.xyz");
+  xyzfile << " 5" << endl;
+  xyzfile << " methane" << endl;
+  xyzfile << " C            .000000     .000000     .000000" << endl;
+  xyzfile << " H            .629118     .629118     .629118" << endl;
+  xyzfile << " H           -.629118    -.629118     .629118" << endl;
+  xyzfile << " H            .629118    -.629118    -.629118" << endl;
+  xyzfile << " H           -.629118     .629118    -.629118" << endl;
+  xyzfile.close();
+
+  std::ofstream basisfile("3-21G.xml");
+  basisfile <<"<basis name=\"3-21G\">" << endl;
+  basisfile << "  <element name=\"H\">" << endl;
+  basisfile << "    <shell scale=\"1.0\" type=\"S\">" << endl;
+  basisfile << "      <constant decay=\"5.447178e+00\">" << endl;
+  basisfile << "        <contractions factor=\"1.562850e-01\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "      <constant decay=\"8.245470e-01\">" << endl;
+  basisfile << "        <contractions factor=\"9.046910e-01\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "    </shell>" << endl;
+  basisfile << "    <shell scale=\"1.0\" type=\"S\">" << endl;
+  basisfile << "      <constant decay=\"1.831920e-01\">" << endl;
+  basisfile << "        <contractions factor=\"1.000000e+00\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "    </shell>" << endl;
+  basisfile << "  </element>" << endl;
+  basisfile << "  <element name=\"C\">" << endl;
+  basisfile << "    <shell scale=\"1.0\" type=\"S\">" << endl;
+  basisfile << "      <constant decay=\"1.722560e+02\">" << endl;
+  basisfile << "        <contractions factor=\"6.176690e-02\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "      <constant decay=\"2.591090e+01\">" << endl;
+  basisfile << "        <contractions factor=\"3.587940e-01\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "      <constant decay=\"5.533350e+00\">" << endl;
+  basisfile << "        <contractions factor=\"7.007130e-01\" type=\"S\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "    </shell>" << endl;
+  basisfile << "    <shell scale=\"1.0\" type=\"SP\">" << endl;
+  basisfile << "      <constant decay=\"3.664980e+00\">" << endl;
+  basisfile << "        <contractions factor=\"-3.958970e-01\" type=\"S\"/>" << endl;
+  basisfile << "        <contractions factor=\"2.364600e-01\" type=\"P\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "      <constant decay=\"7.705450e-01\">" << endl;
+  basisfile << "        <contractions factor=\"1.215840e+00\" type=\"S\"/>" << endl;
+  basisfile << "        <contractions factor=\"8.606190e-01\" type=\"P\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "    </shell>" << endl;
+  basisfile << "    <shell scale=\"1.0\" type=\"SP\">" << endl;
+  basisfile << "      <constant decay=\"1.958570e-01\">" << endl;
+  basisfile << "        <contractions factor=\"1.000000e+00\" type=\"S\"/>" << endl;
+  basisfile << "        <contractions factor=\"1.000000e+00\" type=\"P\"/>" << endl;
+  basisfile << "      </constant>" << endl;
+  basisfile << "    </shell>" << endl;
+  basisfile << "  </element>" << endl;
+  basisfile << "</basis>" << endl;
+  basisfile.close();
+  
+  Orbitals orbitals;
+  orbitals.LoadFromXYZ("molecule.xyz");
+  BasisSet basis;
+  basis.LoadBasisSet("3-21G.xml");
+  orbitals.setDFTbasis("3-21G.xml");
+  AOBasis aobasis;
+  aobasis.AOBasisFill(basis,orbitals.QMAtoms());
+
+  orbitals.setBasisSetSize(17);
+  orbitals.setNumberOfLevels(4,13);
+ Eigen::MatrixXd& MOs=orbitals.MOCoefficients();
+MOs=Eigen::MatrixXd::Zero(17,17);
+MOs<<-0.00761992, -4.69664e-13, 8.35009e-15, -1.15214e-14, -0.0156169, -2.23157e-12, 1.52916e-14, 2.10997e-15, 8.21478e-15, 3.18517e-15, 2.89043e-13, -0.00949189, 1.95787e-12, 1.22168e-14, -2.63092e-15, -0.22227, 1.00844,
+0.233602, -3.18103e-12, 4.05093e-14, -4.70943e-14, 0.1578, 4.75897e-11, -1.87447e-13, -1.02418e-14, 6.44484e-14, -2.6602e-14, 6.5906e-12, -0.281033, -6.67755e-12, 2.70339e-14, -9.78783e-14, -1.94373, -0.36629,
+-1.63678e-13, -0.22745, -0.054851, 0.30351, 3.78688e-11, -0.201627, -0.158318, -0.233561, -0.0509347, -0.650424, 0.452606, -5.88565e-11, 0.453936, -0.165715, -0.619056, 7.0149e-12, 2.395e-14,
+-4.51653e-14, -0.216509, 0.296975, -0.108582, 3.79159e-11, -0.199301, 0.283114, -0.0198557, 0.584622, 0.275311, 0.461431, -5.93732e-11, 0.453057, 0.619523, 0.166374, 7.13235e-12, 2.56811e-14,
+-9.0903e-14, -0.21966, -0.235919, -0.207249, 3.75979e-11, -0.199736, -0.122681, 0.255585, -0.534902, 0.362837, 0.461224, -5.91028e-11, 0.453245, -0.453298, 0.453695, 7.01644e-12, 2.60987e-14,
+0.480866, 1.8992e-11, -2.56795e-13, 4.14571e-13, 2.2709, 4.78615e-10, -2.39153e-12, -2.53852e-13, -2.15605e-13, -2.80359e-13, 7.00137e-12, 0.145171, -1.96136e-11, -2.24876e-13, -2.57294e-14, 4.04176, 0.193617,
+-1.64421e-12, -0.182159, -0.0439288, 0.243073, 1.80753e-10, -0.764779, -0.600505, -0.885907, 0.0862014, 1.10077, -0.765985, 6.65828e-11, -0.579266, 0.211468, 0.789976, -1.41532e-11, -1.29659e-13,
+-1.64105e-12, -0.173397, 0.23784, -0.0869607, 1.80537e-10, -0.755957, 1.07386, -0.0753135, -0.989408, -0.465933, -0.78092, 6.72256e-11, -0.578145, -0.790571, -0.212309, -1.42443e-11, -1.31306e-13,
+-1.63849e-12, -0.17592, -0.188941, -0.165981, 1.79403e-10, -0.757606, -0.465334, 0.969444, 0.905262, -0.61406, -0.78057, 6.69453e-11, -0.578385, 0.578453, -0.578959, -1.40917e-11, -1.31002e-13,
+0.129798, -0.274485, 0.00256652, -0.00509635, -0.0118465, 0.141392, -0.000497905, -0.000510338, -0.000526798, -0.00532572, 0.596595, 0.65313, -0.964582, -0.000361559, -0.000717866, -0.195084, 0.0246232,
+0.0541331, -0.255228, 0.00238646, -0.0047388, -0.88576, 1.68364, -0.00592888, -0.00607692, -9.5047e-05, -0.000960887, 0.10764, -0.362701, 1.53456, 0.000575205, 0.00114206, -0.793844, -0.035336,
+0.129798, 0.0863299, -0.0479412, 0.25617, -0.0118465, -0.0464689, 0.0750316, 0.110468, -0.0436647, -0.558989, -0.203909, 0.65313, 0.320785, 0.235387, 0.878697, -0.195084, 0.0246232,
+0.0541331, 0.0802732, -0.0445777, 0.238198, -0.88576, -0.553335, 0.893449, 1.31541, -0.00787816, -0.100855, -0.0367902, -0.362701, -0.510338, -0.374479, -1.39792, -0.793844, -0.035336,
+0.129798, 0.0927742, -0.197727, -0.166347, -0.0118465, -0.0473592, 0.0582544, -0.119815, -0.463559, 0.320126, -0.196433, 0.65313, 0.321765, 0.643254, -0.642737, -0.195084, 0.0246232,
+0.0541331, 0.0862654, -0.183855, -0.154677, -0.88576, -0.563936, 0.693672, -1.42672, -0.0836372, 0.0577585, -0.0354411, -0.362701, -0.511897, -1.02335, 1.02253, -0.793844, -0.035336,
+0.129798, 0.0953806, 0.243102, -0.0847266, -0.0118465, -0.0475639, -0.132788, 0.00985812, 0.507751, 0.244188, -0.196253, 0.65313, 0.322032, -0.87828, -0.235242, -0.195084, 0.0246232,
+0.0541331, 0.088689, 0.226046, -0.0787824, -0.88576, -0.566373, -1.58119, 0.117387, 0.0916104, 0.0440574, -0.0354087, -0.362701, -0.512321, 1.39726, 0.374248, -0.793844, -0.035336;
+
+orbitals.setBSEindices(0,16,1);
+orbitals.setTDAApprox(true);
+
+MatrixXfd spsi_ref=MatrixXfd::Zero(60,1);
+spsi_ref<<-0.000150849,0.00516987,0.0511522,0.00428958,-0.00966668,-0.000155227,1.02978e-08,5.82225e-05,-0.00216177,0.00907102,6.297e-09,-9.84993e-11,0.00159727,
+        0.0039042,0.0481196,0.00495382,-0.0106013,0.00025141,-0.000155626,-0.000382828,-0.00322057,0.0124251,1.32177e-05,6.794e-07,
+        -0.0153713,0.0200649,-0.067081,-0.0122678,0.0117612,-0.00358901,0.00605007,0.00404793,0.0108884,-0.0151075,-0.000513827,
+        -2.64139e-05,-0.0466653,0.0672016,0.021747,-0.0115096,-0.0124868,-0.0115055,0.0187191,0.0124754,0.0149534,0.0112807,-0.00158977,
+        -8.17254e-05,-0.00290157,0.0994541,0.984029,0.017835,-0.0401912,-0.000645537,-7.54896e-08,-5.91055e-05,0.00219348,-0.00920484,1.82832e-08,5.56223e-11;
+
+orbitals.BSESingletCoefficients()=spsi_ref;
+QMState state_trans=QMState("n2s1");
+
+Eigen::Vector3d res_trans=orbitals.CalcElDipole(state_trans);
+Eigen::Vector3d ref_trans=Eigen::Vector3d::Zero();
+ref_trans<<  0.118565, 0.0444239,-0.0505149;
+
+bool check_trans=ref_trans.isApprox(res_trans,0.0001);
+if(!check_trans){
+  std::cout<<"Result transition dipole"<<std::endl;
+  std::cout<<res_trans<<std::endl;
+  std::cout<<"Ref transition dipole"<<std::endl;
+  std::cout<<ref_trans<<std::endl;
+}
+BOOST_CHECK_EQUAL(check_trans, 1);
+
+QMState state_s1=QMState("s1");
+Eigen::Vector3d res_s1=orbitals.CalcElDipole(state_s1);  
+Eigen::Vector3d ref_s1=Eigen::Vector3d::Zero();  
+ref_s1<<-0.15153501734,-0.42406579479,0.033954362839;
+bool check_s1=ref_s1.isApprox(res_s1,0.0001);
+if(!check_s1 ){
+  std::cout<<"Result s1 dipole"<<std::endl;
+  std::cout<<res_s1<<std::endl;
+  std::cout<<"Ref s1 dipole"<<std::endl;
+  std::cout<<ref_s1<<std::endl;
+}
+BOOST_CHECK_EQUAL(check_s1, 1);
+  
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- closing issue https://github.com/votca/xtp/issues/156
- made BSE errors more explicit
- made AOMatrix::FillBlock a pure virtual function, e.g it has to be implemented by derived class
- converted some member variables to lower case
- aodipole now has a method to set the center around which the dipole can be calculated, defaults to origin
-fixed bug in bse fragment analysis, before it was always executed. 