### PR TITLE
Fix reading and writing bool to hdf5 by casting to/from int

### DIFF
--- a/include/votca/xtp/checkpointreader.h
+++ b/include/votca/xtp/checkpointreader.h
@@ -49,7 +49,7 @@ CheckpointReader(const CptLoc& loc) : _loc(loc){};
     void operator()(bool& v, const std::string& name){
         int temp;
         ReadScalar(_loc, temp, name);
-        v = bool{temp};
+        v = static_cast<bool>(temp);
     }
 
     void operator()(std::string& var, const std::string& name){

--- a/include/votca/xtp/checkpointreader.h
+++ b/include/votca/xtp/checkpointreader.h
@@ -41,9 +41,15 @@ CheckpointReader(const CptLoc& loc) : _loc(loc){};
     }
 
     template<typename T>
-    typename std::enable_if<std::is_fundamental<T>::value>::type
+    typename std::enable_if<std::is_fundamental<T>::value && !std::is_same<T, bool>::value>::type
     operator()(T& var, const std::string& name){
         ReadScalar(_loc, var, name);
+    }
+
+    void operator()(bool& v, const std::string& name){
+        int temp;
+        ReadScalar(_loc, temp, name);
+        v = bool{temp};
     }
 
     void operator()(std::string& var, const std::string& name){

--- a/include/votca/xtp/checkpointwriter.h
+++ b/include/votca/xtp/checkpointwriter.h
@@ -45,11 +45,16 @@ CheckpointWriter(const CptLoc& loc) : _loc(loc){};
     }
 
     // Use this overload iff T is a fundamental type
-    // int, double, unsigned int, etc.
+    // int, double, unsigned int, etc, but not bool
     template<typename T>
-        typename std::enable_if<std::is_fundamental<T>::value>::type
+        typename std::enable_if<std::is_fundamental<T>::value && !std::is_same<T, bool>::value>::type
         operator()(const T& v, const std::string& name){
         WriteScalar(_loc, v, name);
+    }
+
+    void operator()(const bool& v, const std::string& name){
+        int temp{v};
+        WriteScalar(_loc, temp, name);
     }
 
     void operator()(const std::string& v, const std::string& name){

--- a/include/votca/xtp/checkpointwriter.h
+++ b/include/votca/xtp/checkpointwriter.h
@@ -53,7 +53,7 @@ CheckpointWriter(const CptLoc& loc) : _loc(loc){};
     }
 
     void operator()(const bool& v, const std::string& name){
-        int temp{v};
+        int temp=static_cast<int>(v);
         WriteScalar(_loc, temp, name);
     }
 

--- a/src/libxtp/orbitals.cc
+++ b/src/libxtp/orbitals.cc
@@ -687,7 +687,7 @@ namespace votca {
 
                 w(_ScaHFX, "ScaHFX");
 
-                w(int(_useTDA), "useTDA");
+                w(_useTDA, "useTDA");
                 w(_ECP, "ECP");
 
                 w(_QPpert_energies, "QPpert_energies");
@@ -774,9 +774,7 @@ namespace votca {
                 _bse_size = _bse_vtotal * _bse_ctotal;
 
                 r(_ScaHFX, "ScaHFX");
-                int temp;
-                r(temp, "useTDA");
-                _useTDA=bool(temp);
+                r(_useTDA, "useTDA");
                 r(_ECP, "ECP");
 
                 r(_QPpert_energies, "QPpert_energies");


### PR DESCRIPTION
Now we simply cast before and after the read. Just as before the
callers define the type, so it works the same as before but with a
specialized functions dealing with bools.

Fix #159