### PR TITLE
Clean namespace from using

### DIFF
--- a/src/libxtp/bsecoupling.cc
+++ b/src/libxtp/bsecoupling.cc
@@ -26,6 +26,7 @@
 
 namespace votca { namespace xtp {
 
+using namespace std;
 using boost::format;
 using namespace tools;
 

--- a/src/libxtp/dftengine/dftengine.cc
+++ b/src/libxtp/dftengine/dftengine.cc
@@ -34,6 +34,7 @@
 
 using boost::format;
 using namespace boost::filesystem;
+using std;
 using std::flush;
 using namespace votca::tools;
 

--- a/src/libxtp/dftengine/dftengine.cc
+++ b/src/libxtp/dftengine/dftengine.cc
@@ -34,7 +34,7 @@
 
 using boost::format;
 using namespace boost::filesystem;
-using std;
+using namespace std;
 using std::flush;
 using namespace votca::tools;
 

--- a/src/libxtp/gyration.cc
+++ b/src/libxtp/gyration.cc
@@ -21,7 +21,7 @@
 #include <boost/format.hpp>
 #include <votca/tools/elements.h>
 
-
+using namespace std;
 using namespace votca::tools;
 
 namespace votca { namespace xtp {

--- a/src/libxtp/jobcalculators/iexcitoncl.cc
+++ b/src/libxtp/jobcalculators/iexcitoncl.cc
@@ -27,6 +27,7 @@
 
 #include <votca/xtp/logger.h>
 
+using namespace std;
 using namespace boost::filesystem;
 using namespace votca::tools;
 

--- a/src/libxtp/orbitals.cc
+++ b/src/libxtp/orbitals.cc
@@ -32,7 +32,7 @@
 #include <numeric>
 
 
-
+using namespace std;
 using namespace votca::tools;
 
 namespace votca {

--- a/src/libxtp/polarsegment.cc
+++ b/src/libxtp/polarsegment.cc
@@ -26,8 +26,7 @@
 
 #include "votca/xtp/polarsegment.h"
 
-
-
+using namespace std;
 using namespace votca::tools;
 
 namespace votca { namespace xtp {

--- a/src/libxtp/qmmolecule.cc
+++ b/src/libxtp/qmmolecule.cc
@@ -22,8 +22,7 @@
 #include <votca/xtp/checkpointwriter.h>
 #include <votca/xtp/checkpointreader.h>
 
-
-
+using namespace std;
 using namespace votca::tools;
 
 namespace votca { namespace xtp {

--- a/src/tests/test_fragment.cc
+++ b/src/tests/test_fragment.cc
@@ -22,6 +22,7 @@
 #include <votca/tools/vec.h>
 #include <votca/tools/matrix.h>
 
+using namespace std;
 using namespace votca::xtp;
 using namespace votca::tools;
 


### PR DESCRIPTION
Any source files that were missing the using namespace std; line were addressed so that when the header files in tools are fixed it does not create problems for xtp. 