### PR TITLE
Private inheritance of csg basemolecule to xtp molecule

### DIFF
--- a/include/votca/xtp/molecule.h
+++ b/include/votca/xtp/molecule.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2018 The VOTCA Development Team
+ *            Copyright 2009-2019 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -16,64 +16,78 @@
  * limitations under the License.
  *
  */
-/// For earlier commit history see ctp commit 77795ea591b29e664153f9404c8655ba28dc14e9
+/// For earlier commit history see ctp commit
+/// 77795ea591b29e664153f9404c8655ba28dc14e9
 
 #ifndef VOTCA_XTP_MOLECULE_H
 #define VOTCA_XTP_MOLECULE_H
 
+#include "atom.h"
+#include <map>
 #include <string>
 #include <vector>
-#include <map>
+#include <votca/csg/basemolecule.h>
 #include <votca/tools/vec.h>
 
-namespace votca { namespace xtp {
+namespace CSG = votca::csg;
+
+namespace votca {
+namespace xtp {
 
 class Topology;
-class Atom;
 class Fragment;
 class Segment;
 
-class Molecule {
-public:
+/**
+ * @brief The xtp molecule class is essentially a wrapper for csg base molecule
+ *
+ * This class facilitates the mapping atoms, note that the inheritance is
+ * protected, this is intentenial because the base molecule specifically deals
+ * with atoms and not beads. This is of particular importance when making use
+ * of the structural methods available to base molecule.
+ *
+ * E.g. the csg base molecule considers all beads when running structural
+ * analysis methods, this is because the beads are likely to be pseudo-atoms
+ * (as in the hydrogen atoms may be combined with other atoms).
+ *
+ * However, the xtp molecule class explicity treates hydrogen atoms, thus to get
+ * meaninful data from xtp molecule class when dealing with organic molecules
+ * the hydrogen atoms must first be removed from the structure, so that only the
+ * backbone is considered.
+ */
+class Molecule : protected CSG::BaseMolecule<Atom> {
+ public:
+  Molecule(int id, std::string name) {
+    CSG::BaseMolecule<Atom>::id_.setId(id);
+    CSG::BaseMolecule<Atom>::name_.setName(name);
+  }
+  Molecule() {}
+  ~Molecule();
 
-    Molecule(int id, std::string name) : _id(id), _name(name) {}
-    Molecule() { }
-   ~Molecule();
+  int getId() { return CSG::BaseMolecule<Atom>::id_.getId(); }
+  const std::string &getName() { return CSG::BaseMolecule<Atom>::getName(); }
 
-    const int       &getId();
-    const std::string    &getName();
+  void AddSegment(Segment *segment);
+  void AddFragment(Fragment *fragment);
+  void AddAtom(Atom *atom) { CSG::BaseMolecule<Atom>::AddBead(atom); }
 
-    void AddSegment( Segment* segment );
-    void AddFragment( Fragment* fragment);
-    void AddAtom( Atom* atom);
+  std::vector<Fragment *> &Fragments() { return _fragments; }
+  std::vector<Segment *> &Segments() { return _segments; }
 
-    std::vector< Atom* >     &Atoms() { return _atoms; }
-    std::vector< Fragment* > &Fragments() { return _fragments; }
-    std::vector< Segment* >  &Segments() { return _segments; }
+  Atom *getAtom(const int &id) { return CSG::BaseMolecule<Atom>::getBead(id); }
+  size_t AtomCount() { return CSG::BaseMolecule<Atom>::BeadCount(); }
 
-    Atom           *getAtom(const int &id);
-    const std::string   &getAtomType(const int &id);
-    const votca::tools::vec       getAtomPosition(const int &id);
-    int             NumberOfAtoms();
+  inline void setTopology(Topology *container) { _top = container; }
+  Topology *getTopology() { return _top; }
 
-    inline void setTopology(Topology *container) { _top = container; }
-    Topology   *getTopology() { return _top; }
+ private:
+  Topology *_top;
 
-private:
-
-    Topology *_top;
-
-    std::vector < Segment* >   _segments;
-    std::vector < Fragment* >  _fragments;
-    std::vector < Atom* >      _atoms ;
-
-    int     _id;
-    std::string  _name ;
-
-    std::map<std::string, Atom* > _map_AtomName_Atom;
-
+  std::vector<Segment *> _segments;
+  std::vector<Fragment *> _fragments;
 };
 
-}}
+}  // namespace xtp
+}  // namespace votca
 
-#endif // VOTCA_XTP_MOLECULE_H
+#endif  // VOTCA_XTP_MOLECULE_H

--- a/src/libxtp/molecule.cc
+++ b/src/libxtp/molecule.cc
@@ -35,14 +35,7 @@ Molecule::~Molecule() {
 
   _segments.clear();
   _fragments.clear();
-  _atoms.clear();
 }
-
-/// Returns ID of the molecule
-const int &Molecule::getId() { return _id; }
-
-/// Returns the name of the molecule
-const string &Molecule::getName() { return _name; }
 
 void Molecule::AddSegment(Segment *segment) {
   _segments.push_back(segment);
@@ -53,29 +46,5 @@ void Molecule::AddFragment(Fragment *fragment) {
   _fragments.push_back(fragment);
   fragment->setMolecule(this);
 }
-
-void Molecule::AddAtom(Atom *atom) {
-  _atoms.push_back(atom);
-  atom->setMoleculeId(getId());
-}
-
-/// Returns a pointer to the atom
-Atom *Molecule::getAtom(const int &id) {
-  throw runtime_error(string("Not implemented"));
-}
-
-/// Returns atom type
-const string &Molecule::getAtomType(const int &id) {
-  throw runtime_error(string("Not implemented"));
-}
-
-/// Returns atom position
-const vec Molecule::getAtomPosition(const int &id) {
-  throw runtime_error(string("Not implemented"));
-}
-
-/// Returns number of atoms in the molecule
-int Molecule::NumberOfAtoms() { return _atoms.size(); }
-
 }  // namespace xtp
 }  // namespace votca

--- a/src/libxtp/tools/pdb2map.h
+++ b/src/libxtp/tools/pdb2map.h
@@ -207,8 +207,8 @@ void PDB2Map::setTopologies() {
 void PDB2Map::adaptQM2MD() {
 
   // check if atom number is the same in QM and MD
-  int numMDatoms = _MDtop.getMolecule(1)->NumberOfAtoms();
-  int numQMatoms = _QMtop.getMolecule(1)->NumberOfAtoms();
+  size_t numMDatoms = _MDtop.getMolecule(1)->AtomCount();
+  size_t numQMatoms = _QMtop.getMolecule(1)->AtomCount();
 
   _QM2MDcompatible = (numMDatoms == numQMatoms) ? true : false;
 

--- a/src/tests/test_molecule.cc
+++ b/src/tests/test_molecule.cc
@@ -61,8 +61,7 @@ BOOST_AUTO_TEST_CASE(add_atom_test) {
 
   Molecule mol(2, "molecule");
   mol.AddAtom(atm);
-  vector<Atom *> v_atoms = mol.Atoms();
-  BOOST_CHECK_EQUAL(v_atoms.size(), 1);
+  BOOST_CHECK_EQUAL(mol.AtomCount(), 1);
   delete atm;
 }
 


### PR DESCRIPTION
the xtp molecule is a wrapper for the csg basemolecule. Currently, the xtp molecule is not using the structural methods associated with csg base molecule but that will change. Should be built against csg::joshs-development branch to work. 