### PR TITLE
boost::lexical_cast<double> -> stod

### DIFF
--- a/src/libxtp/Md2QmEngine.cc
+++ b/src/libxtp/Md2QmEngine.cc
@@ -247,7 +247,7 @@ void Md2QmEngine::Initialize(const std::string &xmlfile) {
                }
                
                // Mapping weight
-               double weight = boost::lexical_cast<double>(*it_atom_weight);
+               double weight = stod(*it_atom_weight);
                if (!hasQMPart && weight != 0) {
                    std::cout << "ERROR: "
                         << "Atom " << md_atom_name << " in residue "
@@ -574,9 +574,9 @@ void Md2QmEngine::ReadXYZFile(std::string &file,
             // Interesting information written here: e.g. 'C 0.000 0.000 0.000'
             atomCount++;
             std::string element = split[0];
-            double x = boost::lexical_cast<double>( split[1] ) / 10.; //°A to NM
-            double y = boost::lexical_cast<double>( split[2] ) / 10.;
-            double z = boost::lexical_cast<double>( split[3] ) / 10.;
+            double x = stod( split[1] ) / 10.; //°A to NM
+            double y = stod( split[2] ) / 10.;
+            double z = stod( split[3] ) / 10.;
             tools::vec qmPos = tools::vec(x,y,z);
             std::pair<std::string, tools::vec> qmTypePos(element, qmPos);
             intCoords[atomCount] = qmTypePos;

--- a/src/libxtp/calculators/kmclifetime.cc
+++ b/src/libxtp/calculators/kmclifetime.cc
@@ -121,7 +121,7 @@ namespace votca {
 
         for (tools::Property* prop:jobProps) {
             int site_id =prop->getAttribute<int>("id")-1;
-            double lifetime=boost::lexical_cast<double>(prop->value());
+            double lifetime=stod(prop->value());
             bool check=false;
             for (auto& node:_nodes){
                 if (node.id==site_id && !(node.hasdecay)){

--- a/src/libxtp/gdma.cc
+++ b/src/libxtp/gdma.cc
@@ -144,7 +144,7 @@ namespace votca {
                         boost::trim(line);
                         boost::algorithm::split(results, line, boost::is_any_of("\t "),
                                 boost::algorithm::token_compress_on);
-                        double Q00 = boost::lexical_cast<double>(results.back());
+                        double Q00 = stod(results.back());
                         Qs.push_back(Q00);
                     }
 
@@ -157,9 +157,9 @@ namespace votca {
                         boost::trim(line);
                         boost::algorithm::split(results, line, boost::is_any_of("\t "),
                                 boost::algorithm::token_compress_on);
-                        double Q10 = boost::lexical_cast<double>(results[5]);
-                        double Q11c = boost::lexical_cast<double>(results[8]);
-                        double Q11s = boost::lexical_cast<double>(results.back());
+                        double Q10 = stod(results[5]);
+                        double Q11c = stod(results[8]);
+                        double Q11s = stod(results.back());
                         Qs.push_back(Q10);
                         Qs.push_back(Q11c);
                         Qs.push_back(Q11s);
@@ -173,15 +173,15 @@ namespace votca {
                         boost::trim(line);
                         boost::algorithm::split(results, line, boost::is_any_of("\t "),
                                 boost::algorithm::token_compress_on);
-                        double Q20 = boost::lexical_cast<double>(results[5]);
-                        double Q21c = boost::lexical_cast<double>(results[8]);
-                        double Q21s = boost::lexical_cast<double>(results.back());
+                        double Q20 = stod(results[5]);
+                        double Q21c = stod(results[8]);
+                        double Q21s = stod(results.back());
                         getline(gdma_output, line);
                         boost::trim(line);
                         boost::algorithm::split(results, line, boost::is_any_of("\t "),
                                 boost::algorithm::token_compress_on);
-                        double Q22c = boost::lexical_cast<double>(results[2]);
-                        double Q22s = boost::lexical_cast<double>(results[5]);
+                        double Q22c = stod(results[2]);
+                        double Q22s = stod(results[5]);
                         
                         Qs.push_back(Q20);
                         Qs.push_back(Q21c);

--- a/src/libxtp/polarsegment.cc
+++ b/src/libxtp/polarsegment.cc
@@ -86,9 +86,9 @@ void PolarSegment::LoadFromMPS(const std::string& filename){
             string name = split[0];
             Eigen::Vector3d pos;
             int id=_atomlist.size();
-            pos[0] = boost::lexical_cast<double>(split[1]);
-            pos[1] = boost::lexical_cast<double>(split[2]);
-            pos[2] = boost::lexical_cast<double>(split[3]);
+            pos[0] = stod(split[1]);
+            pos[1] = stod(split[2]);
+            pos[2] = stod(split[3]);
             int rank = boost::lexical_cast<int>(split[5]);
             numberofmultipoles=(rank+1)*(rank+1);
             multipoles=Eigen::VectorXd::Zero(numberofmultipoles);
@@ -103,17 +103,17 @@ void PolarSegment::LoadFromMPS(const std::string& filename){
             double      pyy, pyz;
             double           pzz;
             if (split.size() == 7) {
-                pxx = boost::lexical_cast<double>(split[1]);
-                pxy = boost::lexical_cast<double>(split[2]);
-                pxz = boost::lexical_cast<double>(split[3]);
-                pyy = boost::lexical_cast<double>(split[4]);
-                pyz = boost::lexical_cast<double>(split[5]);
-                pzz = boost::lexical_cast<double>(split[6]);
+                pxx = stod(split[1]);
+                pxy = stod(split[2]);
+                pxz = stod(split[3]);
+                pyy = stod(split[4]);
+                pyz = stod(split[5]);
+                pzz = stod(split[6]);
                 p1<<pxx,pxy,pxz,
                     pxy,pyy,pyz,
                     pxz,pyz,pzz;
             }else if (split.size() == 2) {
-                pxx = boost::lexical_cast<double>(split[1]);
+                pxx = stod(split[1]);
                 p1=pxx*Eigen::Matrix3d::Identity();;
             }
             else {
@@ -128,7 +128,7 @@ void PolarSegment::LoadFromMPS(const std::string& filename){
         else {
             // stay in bohr
             for (unsigned i = 0; i < split.size(); i++) {
-                double qXYZ = boost::lexical_cast<double>(split[i]);
+                double qXYZ = stod(split[i]);
                 if(multipoles.size()<readinmultipoles){
                     throw std::runtime_error("ReadMpsFile: File"+filename+"is not properly formatted");
                 }

--- a/src/libxtp/qmmolecule.cc
+++ b/src/libxtp/qmmolecule.cc
@@ -74,9 +74,9 @@ namespace votca { namespace xtp {
                     if(split.size()<4){continue;}
                     // Interesting information written here: e.g. 'C 0.000 0.000 0.000'
                     string element = split[0];
-                    double x = boost::lexical_cast<double>(split[1]);
-                    double y = boost::lexical_cast<double>(split[2]);
-                    double z = boost::lexical_cast<double>(split[3]);
+                    double x = stod(split[1]);
+                    double y = stod(split[2]);
+                    double z = stod(split[3]);
                     Eigen::Vector3d pos = {x, y, z};
                     _atomlist.push_back(QMAtom(atomCount, element, pos * tools::conv::ang2bohr));
                     atomCount++;

--- a/src/libxtp/qmpackages/gaussian.cc
+++ b/src/libxtp/qmpackages/gaussian.cc
@@ -631,7 +631,7 @@ namespace votca {
                             boost::algorithm::token_compress_on);
                     level = boost::lexical_cast<int>(results.front());
                     boost::replace_first(results.back(), "D", "e");
-                    energies[ level ] = boost::lexical_cast<double>(results.back());
+                    energies[ level ] = stod(results.back());
                     levels++;
 
                 } else {
@@ -641,7 +641,7 @@ namespace votca {
                         coefficient.assign(line, 0, 15);
                         boost::trim(coefficient);
                         boost::replace_first(coefficient, "D", "e");
-                        double coef = boost::lexical_cast<double>(coefficient);
+                        double coef = stod(coefficient);
                         coefficients[ level ].push_back(coef);
                         line.erase(0, 15);
                     }
@@ -810,7 +810,7 @@ namespace votca {
                 std::string::size_type HFX_pos = line.find("ScaHFX=");
                 if (HFX_pos != std::string::npos) {
                     boost::algorithm::split(results, line, boost::is_any_of("\t "), boost::algorithm::token_compress_on);
-                    double ScaHFX = boost::lexical_cast<double>(results.back());
+                    double ScaHFX = stod(results.back());
                     orbitals.setScaHFX(ScaHFX);
                     vxc_found = true;
                     XTP_LOG(logDEBUG, *_pLog) << "DFT with " << ScaHFX << " of HF exchange!" << flush;
@@ -924,9 +924,9 @@ namespace votca {
                         std::string atom_type = atom.front();
                         std::vector<std::string>::iterator it_atom;
                         it_atom = atom.end();
-                        double z = boost::lexical_cast<double>(*(--it_atom));
-                        double y = boost::lexical_cast<double>(*(--it_atom));
-                        double x = boost::lexical_cast<double>(*(--it_atom));
+                        double z = stod(*(--it_atom));
+                        double y = stod(*(--it_atom));
+                        double x = stod(*(--it_atom));
                         Eigen::Vector3d pos(x,y,z);
                         pos*=tools::conv::ang2bohr;
                         if (has_atoms == false) {
@@ -950,7 +950,7 @@ namespace votca {
                         properties[property[0]] = property[1];
                     }
                     if (properties.count("HF") > 0) {
-                        double energy_hartree = boost::lexical_cast<double>(properties["HF"]);
+                        double energy_hartree = stod(properties["HF"]);
                         orbitals.setQMEnergy(energy_hartree);
                         XTP_LOG(logDEBUG, *_pLog) << (boost::format("QM energy[Hrt]: %4.6f ") % orbitals.getQMEnergy()).str() << flush;
                     } else {
@@ -968,7 +968,7 @@ namespace votca {
                     std::vector<std::string> energy;
                     boost::algorithm::split(block, line, boost::is_any_of("="), boost::algorithm::token_compress_on);
                     boost::algorithm::split(energy, block[1], boost::is_any_of("\t "), boost::algorithm::token_compress_on);
-                    orbitals.setSelfEnergy(boost::lexical_cast<double> (energy[1]));
+                    orbitals.setSelfEnergy(stod (energy[1]));
                     XTP_LOG(logDEBUG, *_pLog) << "Self energy " << orbitals.getSelfEnergy() << flush;
 
                 }
@@ -1003,8 +1003,8 @@ namespace votca {
                             for (std::string& coefficient: row) {
                                 boost::replace_first(coefficient, "D", "e");
                                 int j_index = *j_iter;
-                                overlap(i_index - 1, j_index - 1) = boost::lexical_cast<double>(coefficient);
-                                overlap(j_index - 1, i_index - 1) = boost::lexical_cast<double>(coefficient);
+                                overlap(i_index - 1, j_index - 1) = stod(coefficient);
+                                overlap(j_index - 1, i_index - 1) = stod(coefficient);
                                 j_iter++;
                             }
                         }
@@ -1064,8 +1064,8 @@ namespace votca {
 
                         int i_index = boost::lexical_cast<int>(row[0]);
                         int j_index = boost::lexical_cast<int>(row[1]);
-                        vxc(i_index - 1, j_index - 1) = boost::lexical_cast<double>(row[2]);
-                        vxc(j_index - 1, i_index - 1) = boost::lexical_cast<double>(row[2]);
+                        vxc(i_index - 1, j_index - 1) = stod(row[2]);
+                        vxc(j_index - 1, i_index - 1) = stod(row[2]);
                     }
 
                     XTP_LOG(logDEBUG, *_pLog) << "Done parsing" << flush;

--- a/src/libxtp/qmpackages/nwchem.cc
+++ b/src/libxtp/qmpackages/nwchem.cc
@@ -681,7 +681,7 @@ namespace votca {
           boost::algorithm::split(results, line, boost::is_any_of("="), boost::algorithm::token_compress_on);
           std::string energy = results.back();
           boost::trim(energy);
-                    orbitals.setQMEnergy(boost::lexical_cast<double>(energy));
+                    orbitals.setQMEnergy(stod(energy));
                     XTP_LOG(logDEBUG, *_pLog) << (boost::format("QM energy[Hrt]: %4.6f ") % orbitals.getQMEnergy()).str() << flush;
           has_qm_energy = true;
         }
@@ -742,9 +742,9 @@ namespace votca {
           while (nfields == 6) {
             int atom_id = boost::lexical_cast< int >(row.at(0))-1;
             std::string atom_type = row.at(1);
-            double x = boost::lexical_cast<double>(row.at(3));
-            double y = boost::lexical_cast<double>(row.at(4));
-            double z = boost::lexical_cast<double>(row.at(5));
+            double x = stod(row.at(3));
+            double y = stod(row.at(4));
+            double z = stod(row.at(5));
             Eigen::Vector3d pos(x,y,z);
             pos*=tools::conv::ang2bohr;
             if (has_QMAtoms == false) {
@@ -792,8 +792,8 @@ namespace votca {
                 std::vector<int>::iterator j_iter = j_indeces.begin();
                 for (std::string& coefficient: row) {
                   int j_index = *j_iter;
-                  vxc(i_index - 1, j_index - 1) = boost::lexical_cast<double>(coefficient);
-                  vxc(j_index - 1, i_index - 1) = boost::lexical_cast<double>(coefficient);
+                  vxc(i_index - 1, j_index - 1) = stod(coefficient);
+                  vxc(j_index - 1, i_index - 1) = stod(coefficient);
                   j_iter++;
                 }
               }
@@ -809,7 +809,7 @@ namespace votca {
         if (HFX_pos != std::string::npos) {
 
           boost::algorithm::split(results, line, boost::is_any_of("\t "), boost::algorithm::token_compress_on);
-          double ScaHFX = boost::lexical_cast<double>(results.back());
+          double ScaHFX = stod(results.back());
           orbitals.setScaHFX(ScaHFX);
           XTP_LOG(logDEBUG, *_pLog) << "DFT with " << ScaHFX << " of HF exchange!" << flush;
         }
@@ -846,8 +846,8 @@ namespace votca {
               std::vector<int>::iterator j_iter = j_indeces.begin();
               for (std::string& coefficient: row) {
                 int j_index = *j_iter;
-                orbitals.AOOverlap()(i_index - 1, j_index - 1) = boost::lexical_cast<double>(coefficient);
-                orbitals.AOOverlap()(j_index - 1, i_index - 1) = boost::lexical_cast<double>(coefficient);
+                orbitals.AOOverlap()(i_index - 1, j_index - 1) = stod(coefficient);
+                orbitals.AOOverlap()(j_index - 1, i_index - 1) = stod(coefficient);
                 j_iter++;
               }
             }
@@ -867,7 +867,7 @@ namespace votca {
           std::vector<std::string> energy;
           boost::algorithm::split(block, line, boost::is_any_of("="), boost::algorithm::token_compress_on);
           boost::algorithm::split(energy, block[1], boost::is_any_of("\t "), boost::algorithm::token_compress_on);
-                    orbitals.setSelfEnergy(boost::lexical_cast<double> (energy[1]));
+                    orbitals.setSelfEnergy(stod (energy[1]));
           XTP_LOG(logDEBUG, *_pLog) << "Self energy " << orbitals.getSelfEnergy() << flush;
         }
 

--- a/src/libxtp/qmpackages/orca.cc
+++ b/src/libxtp/qmpackages/orca.cc
@@ -464,9 +464,9 @@ namespace votca {
                     int atom_id = 0;
                     while (nfields == 4) {
                         std::string atom_type = row.at(0);
-                        double x = boost::lexical_cast<double>(row.at(1));
-                        double y = boost::lexical_cast<double>(row.at(2));
-                        double z = boost::lexical_cast<double>(row.at(3));
+                        double x = stod(row.at(1));
+                        double y = stod(row.at(2));
+                        double z = stod(row.at(3));
                         row=GetLineAndSplit(input_file, "\t ");
                         nfields = row.size();
                         Eigen::Vector3d pos(x,y,z);
@@ -487,14 +487,14 @@ namespace votca {
                     boost::algorithm::split(results, line, boost::is_any_of(" "), boost::algorithm::token_compress_on);
                     std::string energy = results[3];
                     boost::trim(energy);
-                    orbitals.setQMEnergy(boost::lexical_cast<double>(energy));
+                    orbitals.setQMEnergy(stod(energy));
                     XTP_LOG(logDEBUG, *_pLog) << (boost::format("QM energy[Hrt]: %4.6f ") % orbitals.getQMEnergy()).str() << flush;
                 }
 
                 std::string::size_type HFX_pos = line.find("Fraction HF Exchange ScalHFX");
                 if (HFX_pos != std::string::npos) {
                     boost::algorithm::split(results, line, boost::is_any_of(" "), boost::algorithm::token_compress_on);
-                    double ScaHFX = boost::lexical_cast<double>(results.back());
+                    double ScaHFX = stod(results.back());
                     orbitals.setScaHFX(ScaHFX);
                     XTP_LOG(logDEBUG, *_pLog) << "DFT with " << ScaHFX << " of HF exchange!" << flush;
                 }
@@ -529,7 +529,7 @@ namespace votca {
                         }
                         std::string oc = results[1];
                         boost::trim(oc);
-                        double occ = boost::lexical_cast<double>(oc);
+                        double occ = stod(oc);
                         // We only count alpha electrons, each orbital must be empty or doubly occupied
                         if (occ == 2 || occ == 1) {
                             number_of_electrons++;
@@ -547,7 +547,7 @@ namespace votca {
                         }
                         std::string e = results[2];
                         boost::trim(e);
-                        energies [i] = boost::lexical_cast<double>(e);
+                        energies [i] = stod(e);
                     }
                 }
                 /*

--- a/src/libxtp/statefilter.cc
+++ b/src/libxtp/statefilter.cc
@@ -49,7 +49,7 @@ namespace votca {
           } else {
             throw std::runtime_error("statefiler: Fragment label not known, either A or B");
           }
-          _loc_threshold = boost::lexical_cast<double>(strings_vec[1]);
+          _loc_threshold = stod(strings_vec[1]);
         }
 
         if (options.exists("charge_transfer")) {

--- a/src/libxtp/tools/pdb2map.h
+++ b/src/libxtp/tools/pdb2map.h
@@ -383,9 +383,9 @@ void PDB2Map::readPDB(){
             
             try
             {
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
             _resNumInt = boost::lexical_cast<int>(_resNum);
             }
             catch(boost::bad_lexical_cast &)
@@ -538,9 +538,9 @@ void PDB2Map::readGRO(){
                 _resNumInt = boost::lexical_cast<int>(_resNum);
 		//_atNumInt  = boost::lexical_cast<int>(_atNum);
 
-                _xd = boost::lexical_cast<double>(_x);
-                _yd = boost::lexical_cast<double>(_y);
-                _zd = boost::lexical_cast<double>(_z);
+                _xd = stod(_x);
+                _yd = stod(_y);
+                _zd = stod(_z);
             }
             catch (boost::bad_lexical_cast &)
             {
@@ -654,7 +654,7 @@ void PDB2Map::readXYZ(){
         // first line, number of atoms in XYZ
         std::getline(_file, _line,'\n');
         ba::trim(_line);
-        //int numXYZatoms = boost::lexical_cast<double>(_line);
+        //int numXYZatoms = stod(_line);
     }
     catch(boost::bad_lexical_cast &)
     {
@@ -684,9 +684,9 @@ void PDB2Map::readXYZ(){
         // try transform xyz coords to double
         double _xd(0),_yd(0),_zd(0);
         try{
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
         }
         catch(boost::bad_lexical_cast &)
         {

--- a/src/libxtp/tools/pdb2top.h
+++ b/src/libxtp/tools/pdb2top.h
@@ -327,9 +327,9 @@ void PDB2Top::readPDB(){
             
             try
             {
-            _xd = boost::lexical_cast<double>(_x);
-            _yd = boost::lexical_cast<double>(_y);
-            _zd = boost::lexical_cast<double>(_z);
+            _xd = stod(_x);
+            _yd = stod(_y);
+            _zd = stod(_z);
             _resNumInt = boost::lexical_cast<int>(_resNum);
             }
             catch(boost::bad_lexical_cast &)
@@ -477,9 +477,9 @@ void PDB2Top::readGRO(){
                 _resNumInt = boost::lexical_cast<int>(_resNum);
                 //_atNumInt  = boost::lexical_cast<int>(_atNum);
 
-                _xd = boost::lexical_cast<double>(_x);
-                _yd = boost::lexical_cast<double>(_y);
-                _zd = boost::lexical_cast<double>(_z);
+                _xd = stod(_x);
+                _yd = stod(_y);
+                _zd = stod(_z);
             }
             catch (boost::bad_lexical_cast &)
             {


### PR DESCRIPTION
Don't merge, this is just to that I can use it in the fedora package as a patch.

Contains changes from #232 