### PR TITLE
scripts: use python3 for scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 For more detailed information about the changes see the history of the [repository](https://github.com/votca/xtp/commits/master).
 
+## Version 1.5.1 (released XX.11.19)
+ * remove exit() calls in the library 
+ * fix build on CentOs7
+
 ## Version 1.5 _SuperVictor_ (released 31.01.19)
  * enable gitlab CI
 

--- a/scripts/xtp_basisset.in
+++ b/scripts/xtp_basisset.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
 #

--- a/scripts/xtp_makeauxbasis.in
+++ b/scripts/xtp_makeauxbasis.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
 #

--- a/scripts/xtp_update_exciton.in
+++ b/scripts/xtp_update_exciton.in
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 #
 # Copyright 2009-2018 The VOTCA Development Team (http://www.votca.org)
 #


### PR DESCRIPTION
Fix for stable on newer fedora versions.

Part of https://github.com/votca/votca/pull/222