### PR TITLE
Fix rpa indexing

### DIFF
--- a/src/libxtp/gwbse/rpa.cc
+++ b/src/libxtp/gwbse/rpa.cc
@@ -28,18 +28,16 @@ namespace xtp {
 void RPA::UpdateRPAInputEnergies(const Eigen::VectorXd& dftenergies,
                                  const Eigen::VectorXd& gwaenergies,
                                  Index qpmin) {
-  Index rpatotal = _rpamax - _rpamin + 1;
+  const Index rpatotal = _rpamax - _rpamin + 1;
+  const Index qptotal = Index(gwaenergies.size());
+  const Index qpmax = qpmin + qptotal - 1;
+  const Index lumo = _homo + 1;
   _energies = dftenergies.segment(_rpamin, rpatotal);
-  Index gwsize = Index(gwaenergies.size());
-  Index lumo = _homo + 1;
-
-  Index qpmax = qpmin + gwsize - 1;
-  _energies.segment(qpmin, gwsize) = gwaenergies;
+  _energies.segment(qpmin, qptotal) = gwaenergies;
   double DFTgap = dftenergies(lumo) - dftenergies(_homo);
   double QPgap = gwaenergies(lumo - qpmin) - gwaenergies(_homo - qpmin);
   double shift = QPgap - DFTgap;
-  Index levelaboveqpmax = _rpamax - qpmax;
-  _energies.segment(qpmax + 1, levelaboveqpmax).array() += shift;
+  _energies.segment(qpmax + 1, _rpamax - qpmax).array() += shift;
 }
 
 template <bool imag>

--- a/src/libxtp/gwbse/rpa.cc
+++ b/src/libxtp/gwbse/rpa.cc
@@ -34,12 +34,12 @@ void RPA::UpdateRPAInputEnergies(const Eigen::VectorXd& dftenergies,
   Index lumo = _homo + 1;
 
   Index qpmax = qpmin + gwsize - 1;
-  _energies.segment(qpmin - _rpamin, gwsize) = gwaenergies;
+  _energies.segment(qpmin, gwsize) = gwaenergies;
   double DFTgap = dftenergies(lumo) - dftenergies(_homo);
   double QPgap = gwaenergies(lumo - qpmin) - gwaenergies(_homo - qpmin);
   double shift = QPgap - DFTgap;
   Index levelaboveqpmax = _rpamax - qpmax;
-  _energies.segment(qpmax + 1 - _rpamin, levelaboveqpmax).array() += shift;
+  _energies.segment(qpmax + 1, levelaboveqpmax).array() += shift;
 }
 
 template <bool imag>


### PR DESCRIPTION
RPA::UpdateRPAInputEnergies remakes the RPA energies vector `_energies` of size 1 x rpatotal. If I understand it correctly, RPA::UpdateRPAInputEnergies is supposed to do three things:
1. Initialize `_energies` with the DFT energies: `_energies = dftenergies(rpamin:rpamax)`
2. Fill the QP range with the latest GW energies: `_energies(qpmin:qpmax) = gwaenergies`
3. Shift the trailing DFT energies such that they have the same shift (from HOMO-LUMO gap) as the GW energies: `_energies(qpmax+1:end) += (QPGap - DFTGap)`

The problem is: In master, `_energies` is indexed using a `-_rpamin` offset, as if `_energies` is the same size as `dftenergies`. But `_energies` is of size 1 x rpatotal. So indexing of `_energies` should not be offset with `-_rpamin`!

It looks as though `_energies` was at one point the same size as `dftenergies`.

TODO: Is the same indexing mistake in other places?