### PR TITLE
xml and logger update

### DIFF
--- a/share/packages/xtpdft.xml
+++ b/share/packages/xtpdft.xml
@@ -10,6 +10,7 @@
     <DIIS_length help="old hamiltonians to keep in history">20</DIIS_length>
     <levelshift help="levelshift to apply to hamiltonian " unit="hartree">0.0</levelshift>
     <levelshift_end help="DIIS error at levelshifting is disabled">0.2</levelshift_end>
+    <max_iterations help="max iterations to use">200</max_iterations>
 </convergence>
 <initial_guess help="Method to use to make initial guess, independent(electrons) or atom(densities)">atom</initial_guess>
 <basisset help="basiset to use">ubecppol</basisset>
@@ -17,7 +18,6 @@
 <auxbasisset help="auxiliary to use, Delete if you do not want to use RI approximation">aux-ubecppol</auxbasisset>  
 <integration_grid help="grid quality xcoarse,coarse,medium,fine,xfine">medium</integration_grid>
 <xc_functional help="functional name(s) according to LIBXC">XC_HYB_GGA_XC_PBEH</xc_functional>
-<max_iterations help="max iterations to use">200</max_iterations>
 <read_guess help="try to read guess from orbitals file">0</read_guess>
 <cleanup help="files to delete identified by fileending"></cleanup>
 </package>

--- a/src/libxtp/jobcalculators/iqm.cc
+++ b/src/libxtp/jobcalculators/iqm.cc
@@ -412,6 +412,7 @@ Job::JobResult IQM::EvalJob(const Topology& top, Job& job, QMThread& opThread) {
       bool _run_dft_status = qmpackage->Run();
       if (!_run_dft_status) {
         SetJobToFailed(jres, pLog, qmpackage->getPackageName() + " run failed");
+        WriteLoggerToFile(work_dir + "/dft.log", dft_logger);
         return jres;
       }
     }


### PR DESCRIPTION
While using votca I encountered two "problems". 

The first, in the `iqm.cc` file, a log file for the dft calculation is only created if the dft calculation is successful. On failure, however, no `dft.log` is printed. I simply added a line of code that prints a `dft.log` on failure.

The second, in the `xtpdft.xml` file, `max_iterations` was placed in the `package` element, but the code tries to read it from the `package/convergence` element. I simply moved it so the code can read it. (for how the option is read see: `dftengine.cc` line 114)


