### PR TITLE
Better option for Hqp offdiagonals in BSE 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For more detailed information about the changes see the history of the
 * Fixed Cuda implementation (#391)
 * Use a general syntax to represent all QMPackages input (#318)
 * Remove support for both Gaussian and NWChem (#318) 
-* Usage of offdiagonal elements of Hqp in BSE optional (#402)
+* Usage of offdiagonal elements of Hqp in BSE optional, default: with offdiagonals (#402)
 
 >>>>>>> master
 ## Version 1.6 _SuperPelagia_ (released XX.02.20)

--- a/include/votca/xtp/bse.h
+++ b/include/votca/xtp/bse.h
@@ -62,7 +62,7 @@ class BSE {
     Index davidson_maxiter = 50;
     double min_print_weight =
         0.5;  // minimium contribution for state to print it
-    bool use_Hqp_offdiag = false;
+    bool use_Hqp_offdiag = true;
   };
 
   void configure(const options& opt, const Eigen::VectorXd& RPAEnergies,

--- a/src/libxtp/gwbse/bse.cc
+++ b/src/libxtp/gwbse/bse.cc
@@ -44,7 +44,11 @@ void BSE::configure(const options& opt, const Eigen::VectorXd& RPAInputEnergies,
   _bse_vtotal = _bse_vmax - _opt.vmin + 1;
   _bse_ctotal = _opt.cmax - _bse_cmin + 1;
   _bse_size = _bse_vtotal * _bse_ctotal;
-  _Hqp = AdjustHqpSize(Hqp_in, RPAInputEnergies);
+  if (_opt.use_Hqp_offdiag) {
+    _Hqp = AdjustHqpSize(Hqp_in, RPAInputEnergies);
+  } else {
+    _Hqp = AdjustHqpSize(Hqp_in, RPAInputEnergies).diagonal().asDiagonal();
+  }
   SetupDirectInteractionOperator(RPAInputEnergies);
 }
 

--- a/src/libxtp/gwbse/gwbse.cc
+++ b/src/libxtp/gwbse/gwbse.cc
@@ -707,12 +707,7 @@ bool GWBSE::Evaluate() {
   if (_do_bse_singlets || _do_bse_triplets) {
 
     BSE bse = BSE(*_pLog, Mmn);
-    if (_bseopt.use_Hqp_offdiag) {
-      bse.configure(_bseopt, _orbitals.RPAInputEnergies(), Hqp);
-    } else {
-      bse.configure(_bseopt, _orbitals.RPAInputEnergies(),
-                    Hqp.diagonal().asDiagonal());
-    }
+    bse.configure(_bseopt, _orbitals.RPAInputEnergies(), Hqp);
     if (_do_bse_triplets) {
       bse.Solve_triplets(_orbitals);
       XTP_LOG(Log::error, *_pLog)

--- a/src/tests/test_bse.cc
+++ b/src/tests/test_bse.cc
@@ -249,6 +249,78 @@ BOOST_AUTO_TEST_CASE(bse_hamiltonian) {
   // TDA Singlet lapack, davidson, davidson matrix free
   ////////////////////////////////////////////////////////
 
+  // reference energy singlet, no offdiagonals in Hqp
+  Eigen::VectorXd se_nooffdiag_ref = Eigen::VectorXd::Zero(3);
+  se_nooffdiag_ref << 0.106862, 0.106862, 0.106863;
+
+  // reference singlet coefficients, no offdiagonals in Hqp
+  Eigen::MatrixXd spsi_nooffdiag_ref = Eigen::MatrixXd::Zero(60, 3);
+  spsi_nooffdiag_ref << 0.000607127, 0.0229731, -0.00406647, -0.00214374,
+      0.00410545, 0.0228742, -0.023232, 0.000221523, -0.00221698, -0.00388776,
+      -0.00141272, -0.00844522, 0.00855524, -0.00102477, -0.00376702,
+      0.000354366, 0.00924063, -0.00170887, -1.68897e-08, -7.30539e-09,
+      -1.41464e-09, -0.000399553, -0.0134162, 0.00241123, 0.00327622,
+      0.00224704, 0.0130456, -0.0132318, 0.000961469, 0.00315717, 4.73623e-11,
+      -2.41277e-08, 1.67218e-08, -1.06263e-11, -6.11075e-10, 6.17692e-10,
+      -0.00376757, -0.0945042, 0.0179134, -0.0033488, 0.00986624, 0.0479021,
+      -0.046906, 0.00138455, -0.00579045, -0.00542206, -0.00204946, -0.0118782,
+      0.0113272, -0.00127678, -0.00505523, -0.000860697, -0.0252409, 0.0046849,
+      -0.000321737, -0.0207846, 0.00343177, 0.00113344, 0.0296357, -0.00557715,
+      0.00383593, 0.0027263, 0.0147895, -0.0142376, 0.00131257, 0.0032389,
+      2.62534e-05, 0.00169595, -0.00028, 1.08999e-06, 7.04126e-05, -1.16259e-05,
+      0.0154019, 0.00867262, 0.0451478, -0.017964, 0.0554056, 0.055735,
+      0.0650762, -0.0175624, 0.0226305, 0.012757, -0.0151682, -0.00995265,
+      -0.0127642, -0.00328474, -0.0127777, 0.00396125, 0.00223629, 0.0118498,
+      -0.00664764, -0.00315664, -0.0197415, -0.00478285, -0.00268465,
+      -0.0140804, -0.012011, 0.0182182, 0.0141975, 0.0174373, 0.000514854,
+      0.0124932, 0.000542411, 0.000257571, 0.0016108, 2.25203e-05, 1.06938e-05,
+      6.68786e-05, 0.0452854, -0.00598435, -0.0141927, -0.0660776, -0.0203271,
+      -0.014953, -0.0216302, -0.0311786, 0.0719322, 0.0124298, 0.000593334,
+      0.0129825, 0.0135796, 0.00993452, -0.0146421, 0.0122985, -0.00145851,
+      -0.00396145, -0.0199896, 0.00138426, 0.00650989, -0.0142771, 0.00182775,
+      0.00450375, -0.017313, -0.00281174, -0.0118416, -0.0131535, -0.0113317,
+      0.0197418, 0.00163103, -0.000112957, -0.000531178, 6.7719e-05,
+      -4.68944e-06, -2.20537e-05, 0.0257085, 0.972807, -0.172195, -0.0907762,
+      0.17385, 0.968608, -0.98375, 0.00938037, -0.0938789, -0.0270786,
+      -0.00983958, -0.0588216, 0.0595876, -0.00713774, -0.0262375, 0.00246837,
+      0.0643612, -0.0119023, -1.06896e-07, 1.68654e-07, -1.75356e-07,
+      -0.00114093, -0.0383116, 0.00688553, 0.00935525, 0.00641671, 0.0372534,
+      -0.0377848, 0.00274555, 0.00901579, -5.44967e-09, -1.30237e-07,
+      1.03027e-07, -1.60385e-10, -5.02223e-10, 4.11064e-10;
+
+  // lapack
+  opt.davidson = 0;
+  // no offdiagonals
+  opt.use_Hqp_offdiag = false;
+  bse.configure(opt, orbitals.RPAInputEnergies(), Hqp);
+
+  bse.Solve_singlets(orbitals);
+  bool check_se_nooffdiag =
+      se_nooffdiag_ref.isApprox(orbitals.BSESinglets().eigenvalues(), 0.001);
+  if (!check_se_nooffdiag) {
+    cout << "Singlets energy without Hqp offdiag" << endl;
+    cout << orbitals.BSESinglets().eigenvalues() << endl;
+    cout << "Singlets energy without Hqp offdiag ref" << endl;
+    cout << se_nooffdiag_ref << endl;
+  }
+  BOOST_CHECK_EQUAL(check_se_nooffdiag, true);
+  Eigen::MatrixXd projection_nooffdiag =
+      spsi_nooffdiag_ref.transpose() * orbitals.BSESinglets().eigenvectors();
+  Eigen::VectorXd norms_nooffdiag = projection_nooffdiag.colwise().norm();
+  bool check_spsi_nooffdiag = norms_nooffdiag.isApproxToConstant(1, 1e-5);
+  if (!check_spsi_nooffdiag) {
+    cout << "Norms" << norms_nooffdiag << endl;
+    cout << "Singlets psi without Hqp offdiag" << endl;
+    cout << orbitals.BSESinglets().eigenvectors() << endl;
+    cout << "Singlets psi without Hqp offdiag ref" << endl;
+    cout << spsi_nooffdiag_ref << endl;
+  }
+  BOOST_CHECK_EQUAL(check_spsi_nooffdiag, true);
+
+  // with Hqp offdiags
+  opt.use_Hqp_offdiag = true;
+  bse.configure(opt, orbitals.RPAInputEnergies(), Hqp);
+
   // reference energy
   Eigen::VectorXd se_ref = Eigen::VectorXd::Zero(3);
   se_ref << 0.107455, 0.107455, 0.107455;
@@ -287,10 +359,6 @@ BOOST_AUTO_TEST_CASE(bse_hamiltonian) {
       -0.00516415, 0.00138942, 0.00125201, -0.00139237, -0.00501195,
       -0.00519809, -0.000154171, -0.00125602, 4.03664e-08, -6.04796e-08,
       -4.6768e-08, -2.38233e-09, 2.31605e-09, 1.35922e-09;
-
-  // lapack
-  opt.davidson = 0;
-  bse.configure(opt, orbitals.RPAInputEnergies(), Hqp);
 
   // Hqp unchanged
   bool check_hqp_unchanged = Hqp.isApprox(bse.getHqp(), 0.001);


### PR DESCRIPTION
Implements #402 better than #403: 
- moved to BSE object and into configure function
- changed default to using offdiagonals for backwards consistency
- addition to BSE unit test
