### PR TITLE
Refactor of aobasis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ For more detailed information about the changes see the history of the
 * Remove support for both Gaussian and NWChem (#318)
 * Fixed executable path check (#400)
 * Usage of offdiagonal elements of Hqp in BSE optional, default: with offdiagonals (#402)
+* refactored MO reordering of external QMPackages
 
 ## Version 1.6 _SuperPelagia_ (released XX.02.20)
 * fix 32-bit build (#381, #380)

--- a/include/votca/xtp/aobasis.h
+++ b/include/votca/xtp/aobasis.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -28,6 +28,7 @@ namespace votca {
 namespace xtp {
 class QMMolecule;
 class BasisSet;
+class QMPackage;
 
 /**
  * \brief Container to hold Basisfunctions for all atoms
@@ -36,8 +37,8 @@ class BasisSet;
  */
 class AOBasis {
  public:
-  void ReorderMOs(Eigen::MatrixXd& v, const std::string& start,
-                  const std::string& target) const;
+  void ReorderMOs(Eigen::MatrixXd& v, const QMPackage& start,
+                  const QMPackage& target) const;
 
   void Fill(const BasisSet& bs, const QMMolecule& atoms);
 

--- a/include/votca/xtp/aobasis.h
+++ b/include/votca/xtp/aobasis.h
@@ -28,7 +28,6 @@ namespace votca {
 namespace xtp {
 class QMMolecule;
 class BasisSet;
-class QMPackage;
 
 /**
  * \brief Container to hold Basisfunctions for all atoms
@@ -37,9 +36,6 @@ class QMPackage;
  */
 class AOBasis {
  public:
-  void ReorderMOs(Eigen::MatrixXd& v, const QMPackage& start,
-                  const QMPackage& target) const;
-
   void Fill(const BasisSet& bs, const QMMolecule& atoms);
 
   Index AOBasisSize() const { return _AOBasisSize; }
@@ -58,25 +54,6 @@ class AOBasis {
 
  private:
   AOShell& addShell(const Shell& shell, const QMAtom& atom, Index startIndex);
-
-  void MultiplyMOs(Eigen::MatrixXd& v,
-                   const std::vector<Index>& multiplier) const;
-
-  std::vector<Index> invertOrder(const std::vector<Index>& order) const;
-
-  std::vector<Index> getReorderVector(const std::string& start,
-                                      const std::string& target) const;
-
-  void addReorderShell(const std::string& start, const std::string& target,
-                       const std::string& shell,
-                       std::vector<Index>& neworder) const;
-
-  std::vector<Index> getMultiplierVector(const std::string& start,
-                                         const std::string& target) const;
-
-  void addMultiplierShell(const std::string& start, const std::string& target,
-                          const std::string& shell,
-                          std::vector<Index>& multiplier) const;
 
   std::vector<AOShell> _aoshells;
 

--- a/include/votca/xtp/basisset.h
+++ b/include/votca/xtp/basisset.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -31,6 +31,8 @@
 namespace votca {
 namespace xtp {
 // shell type (S, P, D))
+
+bool CheckShellType(const std::string& shelltype);
 
 Index FindLmax(const std::string& type);
 

--- a/include/votca/xtp/qmpackage.h
+++ b/include/votca/xtp/qmpackage.h
@@ -118,6 +118,16 @@ class QMPackage {
   std::vector<std::string> GetLineAndSplit(std::ifstream& input_file,
                                            const std::string separators) const;
 
+  // each qmpackage has its own ordering of the individual functions in each
+  // shell
+  // i.e. VOTCA uses z,y,x e.g. Y1,0 Y1,-1 Y1,1 for the p shell
+  // d3z2-r2 dyz dxz dxy dx2-y2 e.g. Y2,0 Y2,-1 Y2,1 Y2,-2 for the d shell and
+  // so forth. ORCA uses z,x,y for the p shell
+  // these methods reorder the MOs to that format using the
+  // ShellReorder() and ShellMulitplier() which specify the order for each
+  // QMPackage. Some codes also use different normalisation conditions which
+  // lead to other signs for some of the entries, which can be changed via the
+  // multipliers.
   void ReorderMOsToXTP(Eigen::MatrixXd& v, const AOBasis& basis) const;
   void ReorderMOsToNative(Eigen::MatrixXd& v, const AOBasis& basis) const;
 

--- a/include/votca/xtp/qmpackage.h
+++ b/include/votca/xtp/qmpackage.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,8 +18,8 @@
  */
 
 #pragma once
-#ifndef VOTCA_XTP_QM_PACKAGE_H
-#define VOTCA_XTP_QM_PACKAGE_H
+#ifndef VOTCA_XTP_QMPACKAGE_H
+#define VOTCA_XTP_QMPACKAGE_H
 
 #include "votca/xtp/aobasis.h"
 #include <votca/tools/property.h>
@@ -118,6 +118,23 @@ class QMPackage {
   std::vector<std::string> GetLineAndSplit(std::ifstream& input_file,
                                            const std::string separators) const;
 
+  void ReorderMOsToXTP(Eigen::MatrixXd& v, const AOBasis& basis) const;
+  void ReorderMOsToNative(Eigen::MatrixXd& v, const AOBasis& basis) const;
+
+  void ReorderMOs(Eigen::MatrixXd& v, const std::vector<Index>& order) const;
+  void MultiplyMOs(Eigen::MatrixXd& v,
+                   const std::vector<Index>& multiplier) const;
+
+  std::vector<Index> getMultiplierVector(const AOBasis& basis) const;
+  std::vector<Index> getMultiplierShell(const AOShell& shell) const;
+
+  std::vector<Index> getReorderVector(const AOBasis& basis) const;
+  std::vector<Index> getReorderShell(const AOShell& shell) const;
+  std::vector<Index> invertOrder(const std::vector<Index>& order) const;
+
+  virtual const std::array<Index, 25>& ShellMulitplier() const = 0;
+  virtual const std::array<Index, 25>& ShellReorder() const = 0;
+
   Settings _settings{"package"};
 
   Index _charge;
@@ -140,4 +157,4 @@ class QMPackage {
 }  // namespace xtp
 }  // namespace votca
 
-#endif  // VOTCA_XTP_QM_PACKAGE_H
+#endif  // VOTCA_XTP_QMPACKAGE_H

--- a/src/libxtp/aobasis.cc
+++ b/src/libxtp/aobasis.cc
@@ -31,320 +31,40 @@ AOShell& AOBasis::addShell(const Shell& shell, const QMAtom& atom,
   return _aoshells.back();
 }
 
-void AOBasis::ReorderMOs(Eigen::MatrixXd& v, const QMPackage& start,
-                         const QMPackage& target) const {
-
-  if (start.getPackageName() == target.getPackageName()) {
-    return;
-  }
-
-  std::vector<Index> multiplier = getMultiplierVector(target, start);
-  // and reorder rows of _orbitals->_mo_coefficients() accordingly
-  MultiplyMOs(v, multiplier);
-
-  // get reordering vector _start -> target
-  std::vector<Index> order = getReorderVector(start, target);
-
-  // Sanity check
-  if (v.rows() != Index(order.size())) {
-    throw std::runtime_error("Size mismatch in ReorderMOs " +
-                             std::to_string(v.rows()) + ":" +
-                             std::to_string(order.size()));
-  }
-
-  // actual swapping of coefficients
-  for (Index s = 1, d; s < (Index)order.size(); ++s) {
-    for (d = order[s]; d < s; d = order[d]) {
-      ;
-    }
-    if (d == s) {
-      while (d = order[d], d != s) {
-        v.row(s).swap(v.row(d));
-      }
+const std::vector<const AOShell*> AOBasis::getShellsofAtom(Index AtomId) const {
+  std::vector<const AOShell*> result;
+  for (const auto& aoshell : _aoshells) {
+    if (aoshell.getAtomIndex() == AtomId) {
+      result.push_back(&aoshell);
     }
   }
-
-  std::vector<Index> multiplier = getMultiplierVector(start, target);
-  // and reorder rows of _orbitals->_mo_coefficients() accordingly
-  MultiplyMOs(v, multiplier);
+  return result;
 }
-return;
-}  // namespace xtp
 
-void AOBasis::MultiplyMOs(Eigen::MatrixXd& v,
-                          const std::vector<Index>& multiplier) const {
-  // Sanity check
-  if (v.cols() != Index(multiplier.size())) {
-    std::cerr << "Size mismatch in MultiplyMOs" << v.cols() << ":"
-              << multiplier.size() << std::endl;
-    throw std::runtime_error("Abort!");
-  }
-  for (Index i_basis = 0; i_basis < v.cols(); i_basis++) {
-    v.row(i_basis) = multiplier[i_basis] * v.row(i_basis);
+void AOBasis::Fill(const BasisSet& bs, const QMMolecule& atoms) {
+  _AOBasisSize = 0;
+  _aoshells.clear();
+  _FuncperAtom.clear();
+  // loop over atoms
+  for (const QMAtom& atom : atoms) {
+    Index atomfunc = 0;
+    const std::string& name = atom.getElement();
+    const Element& element = bs.getElement(name);
+    for (const Shell& shell : element) {
+      Index numfuncshell = NumFuncShell(shell.getType());
+      AOShell& aoshell = addShell(shell, atom, _AOBasisSize);
+      _AOBasisSize += numfuncshell;
+      atomfunc += numfuncshell;
+      for (const GaussianPrimitive& gaussian : shell) {
+        aoshell.addGaussian(gaussian);
+      }
+      aoshell.CalcMinDecay();
+      aoshell.normalizeContraction();
+    }
+    _FuncperAtom.push_back(atomfunc);
   }
   return;
 }
-
-std::vector<Index> AOBasis::getMultiplierVector(
-    const std::string& start, const std::string& target) const {
-  std::vector<Index> multiplier;
-  multiplier.reserve(_AOBasisSize);
-  std::string s = start;
-  std::string t = target;
-  if (start == "xtp") {
-    s = target;
-    t = start;
-  }
-  // go through basisset
-  for (const AOShell& shell : (*this)) {
-    addMultiplierShell(s, t, shell.getType(), multiplier);
-  }
-  return multiplier;
-}
-
-void AOBasis::addMultiplierShell(const std::string& start,
-                                 const std::string& target,
-                                 const std::string& shell_type,
-                                 std::vector<Index>& multiplier) const {
-  // multipliers were all found using code, hard to establish
-
-  if (target == "xtp") {
-    // single type shells defined here
-
-    for (const char t : shell_type) {
-      if (t == 'S') {
-        multiplier.push_back(1);
-      } else if (t == 'P') {
-        multiplier.push_back(1);
-        multiplier.push_back(1);
-        multiplier.push_back(1);
-      } else if (t == 'D') {
-        if (start == "orca") {
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-        } else {
-          std::cerr << "Tried to get multipliers d-functions from package "
-                    << start << ".";
-          throw std::runtime_error("Multiplication not implemented yet!");
-        }
-      } else if (t == 'F') {
-        if (start == "orca") {
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(-1);
-          multiplier.push_back(-1);
-
-        } else {
-          std::cerr << "Tried to get multipliers f-functions from package "
-                    << start << ".";
-          throw std::runtime_error("Multiplication not implemented yet!");
-        }
-      } else if (t == 'G') {
-        if (start == "orca") {
-          // Not checked yet
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(1);
-          multiplier.push_back(-1);
-          multiplier.push_back(-1);
-          multiplier.push_back(-1);
-          multiplier.push_back(-1);
-
-        } else {
-          std::cerr << "Tried to get multipliers g-functions from package "
-                    << start << ".";
-          throw std::runtime_error("Multiplication not implemented yet!");
-        }
-      } else {
-        std::cerr << "Tried to get multipliers h-functions . ";
-        throw std::runtime_error("Multiplication not implemented yet!");
-      }
-    }
-    else {
-
-      std::cerr << "Tried to reorder functions (multiplier)  from " << start
-                << " to " << target << std::endl;
-      throw std::runtime_error("Reordering not implemented yet!");
-    }
-    return;
-  }
-
-  std::vector<Index> AOBasis::getReorderVector(
-      const std::string& start, const std::string& target) const {
-    std::vector<Index> neworder;
-    neworder.reserve(_AOBasisSize);
-    std::string s;
-    std::string t;
-    if (start == "xtp") {
-      s = target;
-      t = start;
-    } else {
-      s = start;
-      t = target;
-    }
-    // go through basisset
-    for (const AOShell& shell : (*this)) {
-      addReorderShell(s, t, shell.getType(), neworder);
-    }
-    if (start == "xtp") {
-      neworder = invertOrder(neworder);
-    }
-    return neworder;
-  }
-
-  std::vector<Index> AOBasis::invertOrder(const std::vector<Index>& order)
-      const {
-
-    std::vector<Index> neworder = std::vector<Index>(order.size());
-    for (Index i = 0; i < Index(order.size()); i++) {
-      neworder[order[i]] = Index(i);
-    }
-    return neworder;
-  }
-
-  void AOBasis::addReorderShell(
-      const std::string& start, const std::string& target,
-      const std::string& shell_type, std::vector<Index>& order) const {
-    // Reordering is given by email from orca output MOs
-
-    // current length of vector
-
-    Index cur_pos = Index(order.size()) - 1;
-
-    if (target == "xtp") {
-      // single type shells defined here
-      if (shell_type.length() == 1) {
-        if (shell_type == "S") {
-          order.push_back(cur_pos + 1);
-        }  // for S
-
-        // votca order is z,y,x e.g. Y1,0 Y1,-1 Y1,1
-        else if (shell_type == "P") {
-          if (start == "orca") {
-            // orca order is z,x,y Y1,0,Y1,1,Y1,-1
-            order.push_back(cur_pos + 1);
-            order.push_back(cur_pos + 3);
-            order.push_back(cur_pos + 2);
-          } else {
-            std::cerr << "Tried to reorder p-functions from package " << start
-                      << ".";
-            throw std::runtime_error("Reordering not implemented yet!");
-          }
-        }  // for P
-           // votca order is d3z2-r2 dyz dxz dxy dx2-y2 e.g. Y2,0 Y2,-1 Y2,1
-           // Y2,-2 Y2,2
-        else if (shell_type == "D") {
-          // orca order is d3z2-r2 dxz dyz dx2-y2 dxy e.g. Y2,0 Y2,1 Y2,-1 Y2,2
-          // Y2,-2
-          if (start == "orca") {
-            order.push_back(cur_pos + 1);
-            order.push_back(cur_pos + 3);
-            order.push_back(cur_pos + 2);
-            order.push_back(cur_pos + 5);
-            order.push_back(cur_pos + 4);
-          } else {
-            std::cerr << "Tried to reorder d-functions from package " << start
-                      << ".";
-            throw std::runtime_error("Reordering not implemented yet!");
-          }
-        } else if (shell_type == "F") {
-          // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
-          if (start == "orca") {
-            order.push_back(cur_pos + 1);
-            order.push_back(cur_pos + 3);
-            order.push_back(cur_pos + 2);
-            order.push_back(cur_pos + 5);
-            order.push_back(cur_pos + 4);
-            order.push_back(cur_pos + 7);
-            order.push_back(cur_pos + 6);
-          } else {
-            std::cerr << "Tried to reorder f-functions from package " << start
-                      << ".";
-            throw std::runtime_error("Reordering not implemented yet!");
-          }
-        } else if (shell_type == "G") {
-          // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
-          if (start == "orca") {
-            // ordering for orca is Yl,0 Yl,1 Yl,-1 ......Yl,m Yl,-m
-            order.push_back(cur_pos + 1);
-            order.push_back(cur_pos + 3);
-            order.push_back(cur_pos + 2);
-            order.push_back(cur_pos + 5);
-            order.push_back(cur_pos + 4);
-            order.push_back(cur_pos + 7);
-            order.push_back(cur_pos + 6);
-            order.push_back(cur_pos + 9);
-            order.push_back(cur_pos + 8);
-          } else {
-            std::cerr << "Tried to reorder g-functions from package " << start
-                      << ".";
-            throw std::runtime_error("Reordering not implemented");
-          }
-        } else {
-          std::cerr << "Tried to reorder functions  of shell type "
-                    << shell_type << std::endl;
-          throw std::runtime_error("Reordering not implemented");
-        }
-      } else {
-        // for combined shells, iterate over all contributions
-        //_nbf = 0;
-        for (Index i = 0; i < Index(shell_type.length()); ++i) {
-          std::string local_shell = std::string(shell_type, i, 1);
-          this->addReorderShell(start, target, local_shell, order);
-        }
-      }
-
-    } else {
-      std::cerr << "Tried to reorder functions (neworder) from " << start
-                << " to " << target << std::endl;
-      throw std::runtime_error("Reordering not implemented yet!");
-    }
-    return;
-  }
-
-  const std::vector<const AOShell*> AOBasis::getShellsofAtom(Index AtomId)
-      const {
-    std::vector<const AOShell*> result;
-    for (const auto& aoshell : _aoshells) {
-      if (aoshell.getAtomIndex() == AtomId) {
-        result.push_back(&aoshell);
-      }
-    }
-    return result;
-  }
-
-  void AOBasis::Fill(const BasisSet& bs, const QMMolecule& atoms) {
-    _AOBasisSize = 0;
-    _aoshells.clear();
-    _FuncperAtom.clear();
-    // loop over atoms
-    for (const QMAtom& atom : atoms) {
-      Index atomfunc = 0;
-      const std::string& name = atom.getElement();
-      const Element& element = bs.getElement(name);
-      for (const Shell& shell : element) {
-        Index numfuncshell = NumFuncShell(shell.getType());
-        AOShell& aoshell = addShell(shell, atom, _AOBasisSize);
-        _AOBasisSize += numfuncshell;
-        atomfunc += numfuncshell;
-        for (const GaussianPrimitive& gaussian : shell) {
-          aoshell.addGaussian(gaussian);
-        }
-        aoshell.CalcMinDecay();
-        aoshell.normalizeContraction();
-      }
-      _FuncperAtom.push_back(atomfunc);
-    }
-    return;
-  }
 
 }  // namespace xtp
 }  // namespace votca

--- a/src/libxtp/aobasis.cc
+++ b/src/libxtp/aobasis.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -20,6 +20,7 @@
 #include <vector>
 #include <votca/xtp/basisset.h>
 #include <votca/xtp/qmmolecule.h>
+#include <votca/xtp/qmpackage.h>
 
 namespace votca {
 namespace xtp {
@@ -30,18 +31,16 @@ AOShell& AOBasis::addShell(const Shell& shell, const QMAtom& atom,
   return _aoshells.back();
 }
 
-void AOBasis::ReorderMOs(Eigen::MatrixXd& v, const std::string& start,
-                         const std::string& target) const {
+void AOBasis::ReorderMOs(Eigen::MatrixXd& v, const QMPackage& start,
+                         const QMPackage& target) const {
 
-  if (start == target) {
+  if (start.getPackageName() == target.getPackageName()) {
     return;
   }
 
-  if (target == "orca") {
-    std::vector<Index> multiplier = getMultiplierVector(target, start);
-    // and reorder rows of _orbitals->_mo_coefficients() accordingly
-    MultiplyMOs(v, multiplier);
-  }
+  std::vector<Index> multiplier = getMultiplierVector(target, start);
+  // and reorder rows of _orbitals->_mo_coefficients() accordingly
+  MultiplyMOs(v, multiplier);
 
   // get reordering vector _start -> target
   std::vector<Index> order = getReorderVector(start, target);
@@ -65,13 +64,12 @@ void AOBasis::ReorderMOs(Eigen::MatrixXd& v, const std::string& start,
     }
   }
 
-  if (start == "orca") {
-    std::vector<Index> multiplier = getMultiplierVector(start, target);
-    // and reorder rows of _orbitals->_mo_coefficients() accordingly
-    MultiplyMOs(v, multiplier);
-  }
-  return;
+  std::vector<Index> multiplier = getMultiplierVector(start, target);
+  // and reorder rows of _orbitals->_mo_coefficients() accordingly
+  MultiplyMOs(v, multiplier);
 }
+return;
+}  // namespace xtp
 
 void AOBasis::MultiplyMOs(Eigen::MatrixXd& v,
                           const std::vector<Index>& multiplier) const {
@@ -112,14 +110,15 @@ void AOBasis::addMultiplierShell(const std::string& start,
 
   if (target == "xtp") {
     // single type shells defined here
-    if (shell_type.length() == 1) {
-      if (shell_type == "S") {
+
+    for (const char t : shell_type) {
+      if (t == 'S') {
         multiplier.push_back(1);
-      } else if (shell_type == "P") {
+      } else if (t == 'P') {
         multiplier.push_back(1);
         multiplier.push_back(1);
         multiplier.push_back(1);
-      } else if (shell_type == "D") {
+      } else if (t == 'D') {
         if (start == "orca") {
           multiplier.push_back(1);
           multiplier.push_back(1);
@@ -131,7 +130,7 @@ void AOBasis::addMultiplierShell(const std::string& start,
                     << start << ".";
           throw std::runtime_error("Multiplication not implemented yet!");
         }
-      } else if (shell_type == "F") {
+      } else if (t == 'F') {
         if (start == "orca") {
           multiplier.push_back(1);
           multiplier.push_back(1);
@@ -146,7 +145,7 @@ void AOBasis::addMultiplierShell(const std::string& start,
                     << start << ".";
           throw std::runtime_error("Multiplication not implemented yet!");
         }
-      } else if (shell_type == "G") {
+      } else if (t == 'G') {
         if (start == "orca") {
           // Not checked yet
           multiplier.push_back(1);
@@ -168,189 +167,184 @@ void AOBasis::addMultiplierShell(const std::string& start,
         std::cerr << "Tried to get multipliers h-functions . ";
         throw std::runtime_error("Multiplication not implemented yet!");
       }
-    } else {
-      // for combined shells, iterate over all contributions
-      for (Index i = 0; i < Index(shell_type.length()); ++i) {
-        std::string local_shell = std::string(shell_type, i, 1);
-        addMultiplierShell(start, target, local_shell, multiplier);
-      }
     }
-  } else {
+    else {
 
-    std::cerr << "Tried to reorder functions (multiplier)  from " << start
-              << " to " << target << std::endl;
-    throw std::runtime_error("Reordering not implemented yet!");
+      std::cerr << "Tried to reorder functions (multiplier)  from " << start
+                << " to " << target << std::endl;
+      throw std::runtime_error("Reordering not implemented yet!");
+    }
+    return;
   }
-  return;
-}
 
-std::vector<Index> AOBasis::getReorderVector(const std::string& start,
-                                             const std::string& target) const {
-  std::vector<Index> neworder;
-  neworder.reserve(_AOBasisSize);
-  std::string s;
-  std::string t;
-  if (start == "xtp") {
-    s = target;
-    t = start;
-  } else {
-    s = start;
-    t = target;
+  std::vector<Index> AOBasis::getReorderVector(
+      const std::string& start, const std::string& target) const {
+    std::vector<Index> neworder;
+    neworder.reserve(_AOBasisSize);
+    std::string s;
+    std::string t;
+    if (start == "xtp") {
+      s = target;
+      t = start;
+    } else {
+      s = start;
+      t = target;
+    }
+    // go through basisset
+    for (const AOShell& shell : (*this)) {
+      addReorderShell(s, t, shell.getType(), neworder);
+    }
+    if (start == "xtp") {
+      neworder = invertOrder(neworder);
+    }
+    return neworder;
   }
-  // go through basisset
-  for (const AOShell& shell : (*this)) {
-    addReorderShell(s, t, shell.getType(), neworder);
+
+  std::vector<Index> AOBasis::invertOrder(const std::vector<Index>& order)
+      const {
+
+    std::vector<Index> neworder = std::vector<Index>(order.size());
+    for (Index i = 0; i < Index(order.size()); i++) {
+      neworder[order[i]] = Index(i);
+    }
+    return neworder;
   }
-  if (start == "xtp") {
-    neworder = invertOrder(neworder);
-  }
-  return neworder;
-}
 
-std::vector<Index> AOBasis::invertOrder(const std::vector<Index>& order) const {
+  void AOBasis::addReorderShell(
+      const std::string& start, const std::string& target,
+      const std::string& shell_type, std::vector<Index>& order) const {
+    // Reordering is given by email from orca output MOs
 
-  std::vector<Index> neworder = std::vector<Index>(order.size());
-  for (Index i = 0; i < Index(order.size()); i++) {
-    neworder[order[i]] = Index(i);
-  }
-  return neworder;
-}
+    // current length of vector
 
-void AOBasis::addReorderShell(const std::string& start,
-                              const std::string& target,
-                              const std::string& shell_type,
-                              std::vector<Index>& order) const {
-  // Reordering is given by email from orca output MOs
+    Index cur_pos = Index(order.size()) - 1;
 
-  // current length of vector
-
-  Index cur_pos = Index(order.size()) - 1;
-
-  if (target == "xtp") {
-    // single type shells defined here
-    if (shell_type.length() == 1) {
-      if (shell_type == "S") {
-        order.push_back(cur_pos + 1);
-      }  // for S
-
-      // votca order is z,y,x e.g. Y1,0 Y1,-1 Y1,1
-      else if (shell_type == "P") {
-        if (start == "orca") {
-          // orca order is z,x,y Y1,0,Y1,1,Y1,-1
+    if (target == "xtp") {
+      // single type shells defined here
+      if (shell_type.length() == 1) {
+        if (shell_type == "S") {
           order.push_back(cur_pos + 1);
-          order.push_back(cur_pos + 3);
-          order.push_back(cur_pos + 2);
+        }  // for S
+
+        // votca order is z,y,x e.g. Y1,0 Y1,-1 Y1,1
+        else if (shell_type == "P") {
+          if (start == "orca") {
+            // orca order is z,x,y Y1,0,Y1,1,Y1,-1
+            order.push_back(cur_pos + 1);
+            order.push_back(cur_pos + 3);
+            order.push_back(cur_pos + 2);
+          } else {
+            std::cerr << "Tried to reorder p-functions from package " << start
+                      << ".";
+            throw std::runtime_error("Reordering not implemented yet!");
+          }
+        }  // for P
+           // votca order is d3z2-r2 dyz dxz dxy dx2-y2 e.g. Y2,0 Y2,-1 Y2,1
+           // Y2,-2 Y2,2
+        else if (shell_type == "D") {
+          // orca order is d3z2-r2 dxz dyz dx2-y2 dxy e.g. Y2,0 Y2,1 Y2,-1 Y2,2
+          // Y2,-2
+          if (start == "orca") {
+            order.push_back(cur_pos + 1);
+            order.push_back(cur_pos + 3);
+            order.push_back(cur_pos + 2);
+            order.push_back(cur_pos + 5);
+            order.push_back(cur_pos + 4);
+          } else {
+            std::cerr << "Tried to reorder d-functions from package " << start
+                      << ".";
+            throw std::runtime_error("Reordering not implemented yet!");
+          }
+        } else if (shell_type == "F") {
+          // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
+          if (start == "orca") {
+            order.push_back(cur_pos + 1);
+            order.push_back(cur_pos + 3);
+            order.push_back(cur_pos + 2);
+            order.push_back(cur_pos + 5);
+            order.push_back(cur_pos + 4);
+            order.push_back(cur_pos + 7);
+            order.push_back(cur_pos + 6);
+          } else {
+            std::cerr << "Tried to reorder f-functions from package " << start
+                      << ".";
+            throw std::runtime_error("Reordering not implemented yet!");
+          }
+        } else if (shell_type == "G") {
+          // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
+          if (start == "orca") {
+            // ordering for orca is Yl,0 Yl,1 Yl,-1 ......Yl,m Yl,-m
+            order.push_back(cur_pos + 1);
+            order.push_back(cur_pos + 3);
+            order.push_back(cur_pos + 2);
+            order.push_back(cur_pos + 5);
+            order.push_back(cur_pos + 4);
+            order.push_back(cur_pos + 7);
+            order.push_back(cur_pos + 6);
+            order.push_back(cur_pos + 9);
+            order.push_back(cur_pos + 8);
+          } else {
+            std::cerr << "Tried to reorder g-functions from package " << start
+                      << ".";
+            throw std::runtime_error("Reordering not implemented");
+          }
         } else {
-          std::cerr << "Tried to reorder p-functions from package " << start
-                    << ".";
-          throw std::runtime_error("Reordering not implemented yet!");
-        }
-      }  // for P
-         // votca order is d3z2-r2 dyz dxz dxy dx2-y2 e.g. Y2,0 Y2,-1 Y2,1 Y2,-2
-         // Y2,2
-      else if (shell_type == "D") {
-        // orca order is d3z2-r2 dxz dyz dx2-y2 dxy e.g. Y2,0 Y2,1 Y2,-1 Y2,2
-        // Y2,-2
-        if (start == "orca") {
-          order.push_back(cur_pos + 1);
-          order.push_back(cur_pos + 3);
-          order.push_back(cur_pos + 2);
-          order.push_back(cur_pos + 5);
-          order.push_back(cur_pos + 4);
-        } else {
-          std::cerr << "Tried to reorder d-functions from package " << start
-                    << ".";
-          throw std::runtime_error("Reordering not implemented yet!");
-        }
-      } else if (shell_type == "F") {
-        // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
-        if (start == "orca") {
-          order.push_back(cur_pos + 1);
-          order.push_back(cur_pos + 3);
-          order.push_back(cur_pos + 2);
-          order.push_back(cur_pos + 5);
-          order.push_back(cur_pos + 4);
-          order.push_back(cur_pos + 7);
-          order.push_back(cur_pos + 6);
-        } else {
-          std::cerr << "Tried to reorder f-functions from package " << start
-                    << ".";
-          throw std::runtime_error("Reordering not implemented yet!");
-        }
-      } else if (shell_type == "G") {
-        // ordering for votca is Yl,0 Yl,-1 Yl,1 ......Yl,-m Yl,m
-        if (start == "orca") {
-          // ordering for orca is Yl,0 Yl,1 Yl,-1 ......Yl,m Yl,-m
-          order.push_back(cur_pos + 1);
-          order.push_back(cur_pos + 3);
-          order.push_back(cur_pos + 2);
-          order.push_back(cur_pos + 5);
-          order.push_back(cur_pos + 4);
-          order.push_back(cur_pos + 7);
-          order.push_back(cur_pos + 6);
-          order.push_back(cur_pos + 9);
-          order.push_back(cur_pos + 8);
-        } else {
-          std::cerr << "Tried to reorder g-functions from package " << start
-                    << ".";
+          std::cerr << "Tried to reorder functions  of shell type "
+                    << shell_type << std::endl;
           throw std::runtime_error("Reordering not implemented");
         }
       } else {
-        std::cerr << "Tried to reorder functions  of shell type " << shell_type
-                  << std::endl;
-        throw std::runtime_error("Reordering not implemented");
+        // for combined shells, iterate over all contributions
+        //_nbf = 0;
+        for (Index i = 0; i < Index(shell_type.length()); ++i) {
+          std::string local_shell = std::string(shell_type, i, 1);
+          this->addReorderShell(start, target, local_shell, order);
+        }
       }
+
     } else {
-      // for combined shells, iterate over all contributions
-      //_nbf = 0;
-      for (Index i = 0; i < Index(shell_type.length()); ++i) {
-        std::string local_shell = std::string(shell_type, i, 1);
-        this->addReorderShell(start, target, local_shell, order);
+      std::cerr << "Tried to reorder functions (neworder) from " << start
+                << " to " << target << std::endl;
+      throw std::runtime_error("Reordering not implemented yet!");
+    }
+    return;
+  }
+
+  const std::vector<const AOShell*> AOBasis::getShellsofAtom(Index AtomId)
+      const {
+    std::vector<const AOShell*> result;
+    for (const auto& aoshell : _aoshells) {
+      if (aoshell.getAtomIndex() == AtomId) {
+        result.push_back(&aoshell);
       }
     }
-
-  } else {
-    std::cerr << "Tried to reorder functions (neworder) from " << start
-              << " to " << target << std::endl;
-    throw std::runtime_error("Reordering not implemented yet!");
+    return result;
   }
-  return;
-}
 
-const std::vector<const AOShell*> AOBasis::getShellsofAtom(Index AtomId) const {
-  std::vector<const AOShell*> result;
-  for (const auto& aoshell : _aoshells) {
-    if (aoshell.getAtomIndex() == AtomId) {
-      result.push_back(&aoshell);
-    }
-  }
-  return result;
-}
-
-void AOBasis::Fill(const BasisSet& bs, const QMMolecule& atoms) {
-  _AOBasisSize = 0;
-  _aoshells.clear();
-  _FuncperAtom.clear();
-  // loop over atoms
-  for (const QMAtom& atom : atoms) {
-    Index atomfunc = 0;
-    const std::string& name = atom.getElement();
-    const Element& element = bs.getElement(name);
-    for (const Shell& shell : element) {
-      Index numfuncshell = NumFuncShell(shell.getType());
-      AOShell& aoshell = addShell(shell, atom, _AOBasisSize);
-      _AOBasisSize += numfuncshell;
-      atomfunc += numfuncshell;
-      for (const GaussianPrimitive& gaussian : shell) {
-        aoshell.addGaussian(gaussian);
+  void AOBasis::Fill(const BasisSet& bs, const QMMolecule& atoms) {
+    _AOBasisSize = 0;
+    _aoshells.clear();
+    _FuncperAtom.clear();
+    // loop over atoms
+    for (const QMAtom& atom : atoms) {
+      Index atomfunc = 0;
+      const std::string& name = atom.getElement();
+      const Element& element = bs.getElement(name);
+      for (const Shell& shell : element) {
+        Index numfuncshell = NumFuncShell(shell.getType());
+        AOShell& aoshell = addShell(shell, atom, _AOBasisSize);
+        _AOBasisSize += numfuncshell;
+        atomfunc += numfuncshell;
+        for (const GaussianPrimitive& gaussian : shell) {
+          aoshell.addGaussian(gaussian);
+        }
+        aoshell.CalcMinDecay();
+        aoshell.normalizeContraction();
       }
-      aoshell.CalcMinDecay();
-      aoshell.normalizeContraction();
+      _FuncperAtom.push_back(atomfunc);
     }
-    _FuncperAtom.push_back(atomfunc);
+    return;
   }
-  return;
-}
 
 }  // namespace xtp
 }  // namespace votca

--- a/src/libxtp/basisset.cc
+++ b/src/libxtp/basisset.cc
@@ -187,6 +187,28 @@ Index OffsetFuncShell_cartesian(const std::string& shell_type) {
   return nbf;
 }
 
+bool CheckShellType(const std::string& shelltype) {
+  if (shelltype.empty()) {
+    return false;
+  }
+  std::vector<char> allowed_shells = {'S', 'P', 'D', 'F', 'G', 'H', 'I'};
+  std::vector<char>::iterator it =
+      std::find(allowed_shells.begin(), allowed_shells.end(), shelltype[0]);
+  if (it == allowed_shells.end()) {
+    return false;
+  } else {
+    Index index = std::distance(allowed_shells.begin(), it);
+    for (Index i = 1; i < Index(shelltype.size()); i++) {
+      if (index + i > Index(allowed_shells.size()) ||
+          shelltype[i] != allowed_shells[index + i]) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
 void BasisSet::Load(const std::string& name) {
 
   _name = name;
@@ -216,6 +238,10 @@ void BasisSet::Load(const std::string& name) {
     std::vector<tools::Property*> shellProps = elementProp->Select("shell");
     for (tools::Property* shellProp : shellProps) {
       std::string shellType = shellProp->getAttribute<std::string>("type");
+      if (!CheckShellType(shellType)) {
+        throw std::runtime_error("Shelltype: '" + shellType +
+                                 "' is not a valid shelltype!");
+      }
       double shellScale = shellProp->getAttribute<double>("scale");
 
       Shell& shell = element.addShell(shellType, shellScale);

--- a/src/libxtp/basisset.cc
+++ b/src/libxtp/basisset.cc
@@ -142,19 +142,19 @@ Index NumFuncShell_cartesian(const std::string& shell_type) {
   // single type shells defined here
   for (const char& t : shell_type) {
     if (t == 'S') {
-      nbf = 1;
+      nbf += 1;
     } else if (t == 'P') {
-      nbf = 3;
+      nbf += 3;
     } else if (t == 'D') {
-      nbf = 6;
+      nbf += 6;
     } else if (t == 'F') {
-      nbf = 10;
+      nbf += 10;
     } else if (t == 'G') {
-      nbf = 15;
+      nbf += 15;
     } else if (t == 'H') {
-      nbf = 21;
+      nbf += 21;
     } else if (t == 'I') {
-      nbf = 28;
+      nbf += 28;
     } else {
       throw std::runtime_error("NumFuncShell_cartesian shell_type not known");
     }

--- a/src/libxtp/basisset.cc
+++ b/src/libxtp/basisset.cc
@@ -24,7 +24,7 @@ namespace xtp {
 
 Index FindLmax(const std::string& type) {
 
-  assert(!type.empty() && "Shelltype most be non empty!");
+  assert(!type.empty() && "Shelltype must be non empty!");
   const char t = type.back();
   Index lmax = 0;
   if (t == 'S') {
@@ -48,7 +48,7 @@ Index FindLmax(const std::string& type) {
 }
 
 Index FindLmin(const std::string& type) {
-  assert(!type.empty() && "Shelltype most be non empty!");
+  assert(!type.empty() && "Shelltype must be non empty!");
   Index lmin = std::numeric_limits<Index>::max();
   const char t = type[0];
   if (t == 'S') {
@@ -66,14 +66,14 @@ Index FindLmin(const std::string& type) {
   } else if (t == 'I') {
     lmin = 6;
   } else {
-    throw std::runtime_error("FindLmax: Shelltype not known");
+    throw std::runtime_error("FindLmin: Shelltype not known");
   }
   return lmin;
 }
 
 Index OffsetFuncShell(const std::string& shell_type) {
   Index nbf = std::numeric_limits<Index>::max();
-  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  assert(!shell_type.empty() && "Shelltype must be non empty!");
   const char t = shell_type[0];
   if (t == 'S') {
     nbf = 0;
@@ -97,7 +97,7 @@ Index OffsetFuncShell(const std::string& shell_type) {
 
 Index NumFuncShell(const std::string& shell_type) {
   Index nbf = 0;
-  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  assert(!shell_type.empty() && "Shelltype must be non empty!");
   // single type shells
   for (const char& t : shell_type) {
     if (t == 'S') {
@@ -138,7 +138,7 @@ std::vector<Index> NumFuncSubShell(const std::string& shell_type) {
 
 Index NumFuncShell_cartesian(const std::string& shell_type) {
   Index nbf = 0;
-  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  assert(!shell_type.empty() && "Shelltype must be non empty!");
   // single type shells defined here
   for (const char& t : shell_type) {
     if (t == 'S') {
@@ -164,7 +164,7 @@ Index NumFuncShell_cartesian(const std::string& shell_type) {
 
 Index OffsetFuncShell_cartesian(const std::string& shell_type) {
   Index nbf = std::numeric_limits<Index>::max();
-  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  assert(!shell_type.empty() && "Shelltype must be non empty!");
   const char t = shell_type[0];
   if (t == 'S') {
     nbf = 0;

--- a/src/libxtp/basisset.cc
+++ b/src/libxtp/basisset.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -23,135 +23,99 @@ namespace votca {
 namespace xtp {
 
 Index FindLmax(const std::string& type) {
-  Index lmax = std::numeric_limits<Index>::min();
-  // single type shells
-  if (type.length() == 1) {
-    if (type == "S") {
-      lmax = 0;
-    } else if (type == "P") {
-      lmax = 1;
-    } else if (type == "D") {
-      lmax = 2;
-    } else if (type == "F") {
-      lmax = 3;
-    } else if (type == "G") {
-      lmax = 4;
-    } else if (type == "H") {
-      lmax = 5;
-    } else if (type == "I") {
-      lmax = 6;
-    } else {
-      throw std::runtime_error("FindLmax: Shelltype not known");
-    }
+
+  assert(!type.empty() && "Shelltype most be non empty!");
+  const char t = type.back();
+  Index lmax = 0;
+  if (t == 'S') {
+    lmax = 0;
+  } else if (t == 'P') {
+    lmax = 1;
+  } else if (t == 'D') {
+    lmax = 2;
+  } else if (t == 'F') {
+    lmax = 3;
+  } else if (t == 'G') {
+    lmax = 4;
+  } else if (t == 'H') {
+    lmax = 5;
+  } else if (t == 'I') {
+    lmax = 6;
   } else {
-    for (Index i = 0; i < Index(type.length()); ++i) {
-      std::string local_shell = std::string(type, i, 1);
-      Index test = FindLmax(local_shell);
-      if (test > lmax) {
-        lmax = test;
-      }
-    }
+    throw std::runtime_error("FindLmax: Shelltype not known");
   }
   return lmax;
 }
 
 Index FindLmin(const std::string& type) {
+  assert(!type.empty() && "Shelltype most be non empty!");
   Index lmin = std::numeric_limits<Index>::max();
-  if (type.length() == 1) {
-    if (type == "S") {
-      lmin = 0;
-    } else if (type == "P") {
-      lmin = 1;
-    } else if (type == "D") {
-      lmin = 2;
-    } else if (type == "F") {
-      lmin = 3;
-    } else if (type == "G") {
-      lmin = 4;
-    } else if (type == "H") {
-      lmin = 5;
-    } else if (type == "I") {
-      lmin = 6;
-    }
-
-    else {
-      throw std::runtime_error("FindLmax: Shelltype not known");
-    }
+  const char t = type[0];
+  if (t == 'S') {
+    lmin = 0;
+  } else if (t == 'P') {
+    lmin = 1;
+  } else if (t == 'D') {
+    lmin = 2;
+  } else if (t == 'F') {
+    lmin = 3;
+  } else if (t == 'G') {
+    lmin = 4;
+  } else if (t == 'H') {
+    lmin = 5;
+  } else if (t == 'I') {
+    lmin = 6;
   } else {
-    for (Index i = 0; i < Index(type.length()); ++i) {
-      std::string local_shell = std::string(type, i, 1);
-      Index test = FindLmin(local_shell);
-      if (test == 0) {
-        return 0;
-      }
-      if (test < lmin) {
-        lmin = test;
-      }
-    }
+    throw std::runtime_error("FindLmax: Shelltype not known");
   }
   return lmin;
 }
 
 Index OffsetFuncShell(const std::string& shell_type) {
   Index nbf = std::numeric_limits<Index>::max();
-  // single type shells
-  if (shell_type.length() == 1) {
-    if (shell_type == "S") {
-      nbf = 0;
-    } else if (shell_type == "P") {
-      nbf = 1;
-    } else if (shell_type == "D") {
-      nbf = 4;
-    } else if (shell_type == "F") {
-      nbf = 9;
-    } else if (shell_type == "G") {
-      nbf = 16;
-    } else if (shell_type == "H") {
-      nbf = 25;
-    } else if (shell_type == "I") {
-      nbf = 36;
-    } else {
-      throw std::runtime_error("OffsetFuncShell: Shelltype not known");
-    }
+  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  const char t = shell_type[0];
+  if (t == 'S') {
+    nbf = 0;
+  } else if (t == 'P') {
+    nbf = 1;
+  } else if (t == 'D') {
+    nbf = 4;
+  } else if (t == 'F') {
+    nbf = 9;
+  } else if (t == 'G') {
+    nbf = 16;
+  } else if (t == 'H') {
+    nbf = 25;
+  } else if (t == 'I') {
+    nbf = 36;
   } else {
-    // for combined shells, go over all contributions and find minimal offset
-    for (Index i = 0; i < Index(shell_type.length()); ++i) {
-      std::string local_shell = std::string(shell_type, i, 1);
-      Index test = OffsetFuncShell(local_shell);
-      if (test < nbf) {
-        nbf = test;
-      }
-    }
+    throw std::runtime_error("OffsetFuncShell: Shelltype not known");
   }
   return nbf;
 }
 
 Index NumFuncShell(const std::string& shell_type) {
   Index nbf = 0;
+  assert(!shell_type.empty() && "Shelltype most be non empty!");
   // single type shells
-  if (shell_type.length() == 1) {
-    if (shell_type == "S") {
-      nbf = 1;
-    } else if (shell_type == "P") {
-      nbf = 3;
-    } else if (shell_type == "D") {
-      nbf = 5;
-    } else if (shell_type == "F") {
-      nbf = 7;
-    } else if (shell_type == "G") {
-      nbf = 9;
-    } else if (shell_type == "H") {
-      nbf = 11;
-    } else if (shell_type == "I") {
-      nbf = 13;
+  for (const char& t : shell_type) {
+    if (t == 'S') {
+      nbf += 1;
+    } else if (t == 'P') {
+      nbf += 3;
+    } else if (t == 'D') {
+      nbf += 5;
+    } else if (t == 'F') {
+      nbf += 7;
+    } else if (t == 'G') {
+      nbf += 9;
+    } else if (t == 'H') {
+      nbf += 11;
+    } else if (t == 'I') {
+      nbf += 13;
     } else {
       throw std::runtime_error("FindnumofFunc: Shelltype not known");
-    }
-  } else {
-    // for combined shells, go over all contributions and add functions
-    for (Index i = 0; i < Index(shell_type.length()); ++i) {
-      std::string local_shell = std::string(shell_type, i, 1);
-      nbf += NumFuncShell(local_shell);
     }
   }
   return nbf;
@@ -174,69 +138,52 @@ std::vector<Index> NumFuncSubShell(const std::string& shell_type) {
 
 Index NumFuncShell_cartesian(const std::string& shell_type) {
   Index nbf = 0;
+  assert(!shell_type.empty() && "Shelltype most be non empty!");
   // single type shells defined here
-  if (shell_type.length() == 1) {
-    if (shell_type == "S") {
+  for (const char& t : shell_type) {
+    if (t == 'S') {
       nbf = 1;
-    } else if (shell_type == "P") {
+    } else if (t == 'P') {
       nbf = 3;
-    } else if (shell_type == "D") {
+    } else if (t == 'D') {
       nbf = 6;
-    } else if (shell_type == "F") {
+    } else if (t == 'F') {
       nbf = 10;
-    } else if (shell_type == "G") {
+    } else if (t == 'G') {
       nbf = 15;
-    } else if (shell_type == "H") {
+    } else if (t == 'H') {
       nbf = 21;
-    } else if (shell_type == "I") {
+    } else if (t == 'I') {
       nbf = 28;
     } else {
       throw std::runtime_error("NumFuncShell_cartesian shell_type not known");
     }
-  } else {
-    // for combined shells, sum over all contributions
-    for (Index i = 0; i < Index(shell_type.length()); ++i) {
-      std::string local_shell = std::string(shell_type, i, 1);
-      nbf += NumFuncShell_cartesian(local_shell);
-    }
   }
-
   return nbf;
 }
 
 Index OffsetFuncShell_cartesian(const std::string& shell_type) {
-  Index nbf;
-  // single type shells
-  if (shell_type.length() == 1) {
-    if (shell_type == "S") {
-      nbf = 0;
-    } else if (shell_type == "P") {
-      nbf = 1;
-    } else if (shell_type == "D") {
-      nbf = 4;
-    } else if (shell_type == "F") {
-      nbf = 10;
-    } else if (shell_type == "G") {
-      nbf = 20;
-    } else if (shell_type == "H") {
-      nbf = 35;
-    } else if (shell_type == "I") {
-      nbf = 56;
-    } else {
-      throw std::runtime_error(
-          "OffsetFuncShell_cartesian shell_type not known");
-    }
+  Index nbf = std::numeric_limits<Index>::max();
+  assert(!shell_type.empty() && "Shelltype most be non empty!");
+  const char t = shell_type[0];
+  if (t == 'S') {
+    nbf = 0;
+  } else if (t == 'P') {
+    nbf = 1;
+  } else if (t == 'D') {
+    nbf = 4;
+  } else if (t == 'F') {
+    nbf = 10;
+  } else if (t == 'G') {
+    nbf = 20;
+  } else if (t == 'H') {
+    nbf = 35;
+  } else if (t == 'I') {
+    nbf = 56;
   } else {
-    // for combined shells, go over all contributions and find minimal offset
-    nbf = 1000;
-    for (Index i = 0; i < Index(shell_type.length()); ++i) {
-      std::string local_shell = std::string(shell_type, i, 1);
-      Index test = OffsetFuncShell_cartesian(local_shell);
-      if (test < nbf) {
-        nbf = test;
-      }
-    }
+    throw std::runtime_error("OffsetFuncShell_cartesian shell_type not known");
   }
+
   return nbf;
 }
 

--- a/src/libxtp/qmpackage.cc
+++ b/src/libxtp/qmpackage.cc
@@ -21,6 +21,7 @@
 #include <votca/xtp/ecpaobasis.h>
 #include <votca/xtp/orbitals.h>
 #include <votca/xtp/qmpackage.h>
+#include <votca/xtp/qmpackagefactory.h>
 
 namespace votca {
 namespace xtp {
@@ -69,7 +70,10 @@ void QMPackage::ReorderOutput(Orbitals& orbitals) const {
   }
 
   if (orbitals.hasMOs()) {
-    dftbasis.ReorderMOs(orbitals.MOs().eigenvectors(), getPackageName(), "xtp");
+    QMPackageFactory::RegisterAll();
+    std::unique_ptr<QMPackage> xtp =
+        std::unique_ptr<QMPackage>(QMPackages().Create("xtp"));
+    dftbasis.ReorderMOs(orbitals.MOs().eigenvectors(), *this, *xtp);
     XTP_LOG(Log::info, *_pLog) << "Reordered MOs" << flush;
   }
 
@@ -85,7 +89,10 @@ Eigen::MatrixXd QMPackage::ReorderMOsBack(const Orbitals& orbitals) const {
   AOBasis dftbasis;
   dftbasis.Fill(dftbasisset, orbitals.QMAtoms());
   Eigen::MatrixXd result = orbitals.MOs().eigenvectors();
-  dftbasis.ReorderMOs(result, "xtp", getPackageName());
+  QMPackageFactory::RegisterAll();
+  std::unique_ptr<QMPackage> xtp =
+      std::unique_ptr<QMPackage>(QMPackages().Create("xtp"));
+  dftbasis.ReorderMOs(result, *xtp, *this);
   return result;
 }
 

--- a/src/libxtp/qmpackage.cc
+++ b/src/libxtp/qmpackage.cc
@@ -70,10 +70,7 @@ void QMPackage::ReorderOutput(Orbitals& orbitals) const {
   }
 
   if (orbitals.hasMOs()) {
-    QMPackageFactory::RegisterAll();
-    std::unique_ptr<QMPackage> xtp =
-        std::unique_ptr<QMPackage>(QMPackages().Create("xtp"));
-    dftbasis.ReorderMOs(orbitals.MOs().eigenvectors(), *this, *xtp);
+    ReorderMOsToXTP(orbitals.MOs().eigenvectors(), dftbasis);
     XTP_LOG(Log::info, *_pLog) << "Reordered MOs" << flush;
   }
 
@@ -81,18 +78,12 @@ void QMPackage::ReorderOutput(Orbitals& orbitals) const {
 }
 
 Eigen::MatrixXd QMPackage::ReorderMOsBack(const Orbitals& orbitals) const {
-  BasisSet dftbasisset;
-  dftbasisset.Load(_basisset_name);
   if (!orbitals.hasQMAtoms()) {
     throw std::runtime_error("Orbitals object has no QMAtoms");
   }
-  AOBasis dftbasis;
-  dftbasis.Fill(dftbasisset, orbitals.QMAtoms());
+  AOBasis dftbasis = orbitals.SetupDftBasis();
   Eigen::MatrixXd result = orbitals.MOs().eigenvectors();
-  QMPackageFactory::RegisterAll();
-  std::unique_ptr<QMPackage> xtp =
-      std::unique_ptr<QMPackage>(QMPackages().Create("xtp"));
-  dftbasis.ReorderMOs(result, *xtp, *this);
+  ReorderMOsToNative(result, dftbasis);
   return result;
 }
 
@@ -145,6 +136,119 @@ std::string QMPackage::FindDefaultsFile() const {
                  std::string("/xtp/packages/qmpackage_defaults.xml");
 
   return xmlFile;
+}
+
+void QMPackage::ReorderMOs(Eigen::MatrixXd& v,
+                           const std::vector<Index>& order) const {
+  // Sanity check
+  if (v.rows() != Index(order.size())) {
+    throw std::runtime_error("Size mismatch in ReorderMOs " +
+                             std::to_string(v.rows()) + ":" +
+                             std::to_string(order.size()));
+  }
+
+  // actual swapping of coefficients
+  for (Index s = 1, d; s < (Index)order.size(); ++s) {
+    for (d = order[s]; d < s; d = order[d]) {
+      ;
+    }
+    if (d == s) {
+      while (d = order[d], d != s) {
+        v.row(s).swap(v.row(d));
+      }
+    }
+  }
+}
+
+void QMPackage::ReorderMOsToXTP(Eigen::MatrixXd& v,
+                                const AOBasis& basis) const {
+
+  std::vector<Index> multiplier = getMultiplierVector(basis);
+  MultiplyMOs(v, multiplier);
+
+  std::vector<Index> order = getReorderVector(basis);
+  ReorderMOs(v, order);
+  MultiplyMOs(v, multiplier);
+  return;
+}
+
+void QMPackage::ReorderMOsToNative(Eigen::MatrixXd& v,
+                                   const AOBasis& basis) const {
+
+  std::vector<Index> multiplier = getMultiplierVector(basis);
+  MultiplyMOs(v, multiplier);
+  std::vector<Index> order = getReorderVector(basis);
+  std::vector<Index> reverseorder = invertOrder(order);
+  ReorderMOs(v, reverseorder);
+  MultiplyMOs(v, multiplier);
+  return;
+}
+
+void QMPackage::MultiplyMOs(Eigen::MatrixXd& v,
+                            const std::vector<Index>& multiplier) const {
+  // Sanity check
+  if (v.cols() != Index(multiplier.size())) {
+    std::cerr << "Size mismatch in MultiplyMOs" << v.cols() << ":"
+              << multiplier.size() << std::endl;
+    throw std::runtime_error("Abort!");
+  }
+  for (Index i = 0; i < v.cols(); i++) {
+    v.row(i) = multiplier[i] * v.row(i);
+  }
+  return;
+}
+
+std::vector<Index> QMPackage::getMultiplierVector(const AOBasis& basis) const {
+  std::vector<Index> multiplier;
+  multiplier.reserve(basis.AOBasisSize());
+  // go through basisset
+  for (const AOShell& shell : basis) {
+    std::vector<Index> shellmultiplier = getMultiplierShell(shell);
+    multiplier.insert(multiplier.end(), shellmultiplier.begin(),
+                      shellmultiplier.end());
+  }
+  return multiplier;
+}
+
+std::vector<Index> QMPackage::getMultiplierShell(const AOShell& shell) const {
+  // multipliers were all found using code, hard to establish
+  std::vector<Index> multiplier;
+  for (Index i = 0; i < shell.getNumFunc(); i++) {
+    multiplier.push_back(ShellMulitplier()[shell.getOffset() + i]);
+  }
+  return multiplier;
+}
+
+std::vector<Index> QMPackage::getReorderVector(const AOBasis& basis) const {
+  std::vector<Index> reorder;
+  reorder.reserve(basis.AOBasisSize());
+  // go through basisset
+  for (const AOShell& shell : basis) {
+    std::vector<Index> shellreorder = getReorderShell(shell);
+    std::for_each(shellreorder.begin(), shellreorder.end(),
+                  [&reorder](Index& i) { i += Index(reorder.size()); });
+    reorder.insert(reorder.end(), shellreorder.begin(), shellreorder.end());
+  }
+  return reorder;
+}
+
+std::vector<Index> QMPackage::getReorderShell(const AOShell& shell) const {
+  // multipliers were all found using code, hard to establish
+  std::vector<Index> reorder;
+  for (Index i = 0; i < shell.getNumFunc(); i++) {
+    reorder.push_back(ShellReorder()[shell.getOffset() + i]);
+  }
+  return reorder;
+}
+
+std::vector<Index> QMPackage::invertOrder(
+    const std::vector<Index>& order) const {
+
+  std::vector<Index> neworder = std::vector<Index>(order.size());
+  for (Index i = 0; i < Index(order.size()); i++) {
+    neworder[order[i]] = Index(i);
+  }
+  return neworder;
 }
 
 }  // namespace xtp

--- a/src/libxtp/qmpackages/orca.h
+++ b/src/libxtp/qmpackages/orca.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,8 +18,8 @@
  */
 
 #pragma once
-#ifndef __VOTCA_XTP_ORCA_H
-#define __VOTCA_XTP_ORCA_H
+#ifndef VOTCA_XTP_ORCA_H
+#define VOTCA_XTP_ORCA_H
 
 #include <votca/xtp/qmpackage.h>
 
@@ -57,7 +57,29 @@ class Orca : public QMPackage {
 
   Eigen::Matrix3d GetPolarizability() const override;
 
+ protected:
+  const std::array<Index, 25>& ShellMulitplier() const final {
+    return _multipliers;
+  }
+  const std::array<Index, 25>& ShellReorder() const final { return _reorder; }
+
  private:
+  // clang-format off
+  std::array<Index,25> _multipliers={
+            1, //s
+            1,1,1, //p
+            1,1,1,1,1, //d
+            1,1,1,1,1,-1,-1, //f 
+            1,1,1,1,1,-1,-1,-1,-1 //g
+            };
+  std::array<Index,25> _reorder={
+            1, //s
+            1,3,2, //p orca order is z,x,y Y1,0,Y1,1,Y1,-1
+            1,3,2,5,4, //d orca order is d3z2-r2 dxz dyz dx2-y2 dxy e.g. Y2,0 Y2,1 Y2,-1 Y2,2
+            1,3,2,5,4,7,6, //f 
+            1,3,2,5,4,7,6,9,8 //g
+            };
+  // clang-format on
   std::string indent(const double& number);
   std::string getLName(Index lnum);
 
@@ -84,4 +106,4 @@ class Orca : public QMPackage {
 }  // namespace xtp
 }  // namespace votca
 
-#endif /* __VOTCA_XTP_ORCA_H */
+#endif  // VOTCA_XTP_ORCA_H

--- a/src/libxtp/qmpackages/xtpdft.h
+++ b/src/libxtp/qmpackages/xtpdft.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -18,8 +18,8 @@
  */
 
 #pragma once
-#ifndef __VOTCA_XTP_XTPDFT_H
-#define __VOTCA_XTP_XTPDFT_H
+#ifndef VOTCA_XTP_XTPDFT_H
+#define VOTCA_XTP_XTPDFT_H
 
 #include <string>
 #include <votca/xtp/dftengine.h>
@@ -38,34 +38,45 @@ namespace xtp {
 
 class XTPDFT : public QMPackage {
  public:
-  std::string getPackageName() const override { return "xtp"; }
+  std::string getPackageName() const final { return "xtp"; }
 
-  void Initialize(tools::Property& options) override;
+  void Initialize(tools::Property& options) final;
 
-  bool WriteInputFile(const Orbitals& orbitals) override;
+  bool WriteInputFile(const Orbitals& orbitals) final;
 
-  bool Run() override;
+  bool Run() final;
 
-  void CleanUp() override;
+  void CleanUp() final;
 
   bool CheckLogFile();
 
-  bool ParseLogFile(Orbitals& orbitals) override;
+  bool ParseLogFile(Orbitals& orbitals) final;
 
-  bool ParseMOsFile(Orbitals& orbitals) override;
+  bool ParseMOsFile(Orbitals& orbitals) final;
 
-  StaticSegment GetCharges() const override {
+  StaticSegment GetCharges() const final {
     throw std::runtime_error(
         "If you want partial charges just run the 'partialcharges' calculator");
   }
 
-  Eigen::Matrix3d GetPolarizability() const override {
+  Eigen::Matrix3d GetPolarizability() const final {
     throw std::runtime_error(
         "GetPolarizability() is not implemented for xtpdft");
   }
 
+ protected:
+  const std::array<Index, 25>& ShellMulitplier() const final {
+    return _multipliers;
+  }
+  const std::array<Index, 25>& ShellReorder() const final { return _reorder; }
+
  private:
-  void WriteChargeOption() override { return; }
+  std::array<Index, 25> _multipliers = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  std::array<Index, 25> _reorder = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                                    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+
+  void WriteChargeOption() final { return; }
   tools::Property _xtpdft_options;
 
   Orbitals _orbitals;
@@ -74,4 +85,4 @@ class XTPDFT : public QMPackage {
 }  // namespace xtp
 }  // namespace votca
 
-#endif /* __VOTCA_XTP_XTPDFT_H */
+#endif  // VOTCA_XTP_XTPDFT_H

--- a/src/tests/test_basisset.cc
+++ b/src/tests/test_basisset.cc
@@ -49,6 +49,15 @@ BOOST_AUTO_TEST_CASE(FreeFunctions_test) {
   BOOST_CHECK_EQUAL(NumFuncShell_cartesian("SPD"), 10);
 
   BOOST_CHECK_EQUAL(OffsetFuncShell_cartesian("FG"), 10);
+
+  BOOST_CHECK_EQUAL(CheckShellType("FG"), true);
+  BOOST_CHECK_EQUAL(CheckShellType("S"), true);
+  BOOST_CHECK_EQUAL(CheckShellType("PD"), true);
+  BOOST_CHECK_EQUAL(CheckShellType("s"), false);
+  BOOST_CHECK_EQUAL(CheckShellType("apdf"), false);
+  BOOST_CHECK_EQUAL(CheckShellType("PDS"), false);
+  BOOST_CHECK_EQUAL(CheckShellType("PDG"), false);
+  BOOST_CHECK_EQUAL(CheckShellType("SDFGI"), false);
 }
 
 BOOST_AUTO_TEST_CASE(Contraction_test) {

--- a/src/tests/test_basisset.cc
+++ b/src/tests/test_basisset.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,30 @@
 using namespace votca::xtp;
 using namespace std;
 BOOST_AUTO_TEST_SUITE(basisset_test)
+
+BOOST_AUTO_TEST_CASE(FreeFunctions_test) {
+
+  BOOST_CHECK_EQUAL(FindLmax("F"), 3);
+  BOOST_CHECK_EQUAL(FindLmax("PDF"), 3);
+  BOOST_REQUIRE_THROW(FindLmax("a"), std::runtime_error);
+
+  BOOST_CHECK_EQUAL(FindLmin("F"), 3);
+  BOOST_CHECK_EQUAL(FindLmin("PDF"), 1);
+
+  BOOST_CHECK_EQUAL(OffsetFuncShell("S"), 0);
+
+  BOOST_CHECK_EQUAL(OffsetFuncShell("D"), 4);
+
+  BOOST_REQUIRE_THROW(OffsetFuncShell("a"), std::runtime_error);
+
+  BOOST_CHECK_EQUAL(NumFuncShell("SPD"), 9);
+
+  BOOST_REQUIRE_THROW(OffsetFuncShell("sfgid"), std::runtime_error);
+
+  BOOST_CHECK_EQUAL(NumFuncShell_cartesian("SPD"), 10);
+
+  BOOST_CHECK_EQUAL(OffsetFuncShell_cartesian("FG"), 10);
+}
 
 BOOST_AUTO_TEST_CASE(Contraction_test) {
   std::ofstream basisfile("contracted.xml");


### PR DESCRIPTION
- Removed all the recursion in basisset.cc and replaced it with for loops for better readability and added some tests
- Moved ReorderMOs from AOBasis to QMPackage
- Input format of types is now checked
- The Reorder parameters are now stored in the qmpackage and not hardcoded in aobasis.cc