### PR TITLE
remove duplicated options in dftgwbse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ For more detailed information about the changes see the history of the
 * Fixed executable path check (#400)
 * Usage of offdiagonal elements of Hqp in BSE optional, default: with offdiagonals (#402)
 * refactored MO reordering of external QMPackages
+* Remove Log and MO files from the `gwbse_engine` options (#414)
 
 ## Version 1.6 _SuperPelagia_ (released XX.02.20)
 * fix 32-bit build (#381, #380)

--- a/include/votca/xtp/settings.h
+++ b/include/votca/xtp/settings.h
@@ -21,13 +21,13 @@
 #define __XTP_SETTINGS__H
 
 #include <algorithm>
+#include <iostream>
 #include <iterator>
 #include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <votca/tools/property.h>
-
 /*
  * \brief Hierarchical representation of a QM Package input
  */
@@ -108,10 +108,12 @@ class Settings {
    */
   bool has_key(const std::string& key) const;
 
-  /**
-   * \brief Check that the input is correct
-   */
-  void validate() const;
+  friend std::ostream& operator<<(std::ostream& os, const Settings& sett) {
+    for (const auto& s : sett._nodes) {
+      os << "key: " << s.first << "\nvalue:" << s.second << "\n";
+    }
+    return os;
+  }
 
  private:
   using Settings_map = std::unordered_map<std::string, votca::tools::Property>;
@@ -121,38 +123,6 @@ class Settings {
   std::string get_primary_key(const std::string& key) {
     return key.substr(0, key.find("."));
   }
-
-  void check_mandatory_keyword(const std::string& key) const;
-
-  std::vector<std::string> _general_properties = {
-      "auxbasisset",            // string
-      "basisset",               // string
-      "charge",                 // index
-      "cleanup",                // string
-      "convergence_tightness",  // std::string
-      "dipole_spacing",         // boolean
-      "ecp",                    // string
-      "executable",             // string
-      // "external_charge",        // Eigen::Vector9d
-      "functional",     // string
-      "name",           // string
-      "optimize",       // boolean
-      "orca",           // string
-      "polarisation",   // boolean
-      "read_guess",     // boolean
-      "spin",           // index
-      "scratch",        // string
-      "write_charges",  // boolean
-      "xtpdft",         // string
-  };
-
-  std::vector<std::string> _mandatory_keyword = {
-      "functional",  // string
-      "name",        // string, one of: orca
-  };
-
-  std::unordered_map<std::string, std::vector<std::string>> _keyword_options{
-      {"name", {"orca"}}};
 };
 
 }  // namespace xtp

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -7,13 +7,7 @@
         <basisset help="Basis set for MOs" default="def2-tzvp">def2-tzvp</basisset>
         <auxbasisset help="Auxiliary basis set for RI" default="aux-def2-tzvp">aux-def2-tzvp</auxbasisset>
         <functional help="functional name(s) according to LIBXC" default="XC_HYB_GGA_XC_PBEH">XC_HYB_GGA_XC_PBEH</functional>
-
-        <dftpackage>
-            <package>
-                <name help="Name of the DFT package" default="xtp">xtp</name>
-                <executable help="Executable of the DFT package" default="xtp">xtp</executable>
-            </package>      
-        </dftpackage>
+        <name help="Name of the DFT package" default="xtp">xtp</name>
 
         <gwbse_engine>
             <tasks help="guess,input,dft,parse,gwbse" default="input,dft,parse,gwbse">input,dft,parse,gwbse</tasks>

--- a/src/libxtp/qmpackage.cc
+++ b/src/libxtp/qmpackage.cc
@@ -30,7 +30,6 @@ using std::flush;
 void QMPackage::ParseCommonOptions(tools::Property& options) {
 
   std::string key = "package";
-  // std::string key = "";
 
   _settings.read_property(options, key);
   char* votca_share = getenv("VOTCASHARE");
@@ -41,7 +40,6 @@ void QMPackage::ParseCommonOptions(tools::Property& options) {
     qmpackage_defaults.load_from_xml(this->FindDefaultsFile());
     _settings.amend(qmpackage_defaults);
   }
-  _settings.validate();
 
   _charge = _settings.get<Index>("charge");
   _spin = _settings.get<Index>("spin");

--- a/src/libxtp/settings.cc
+++ b/src/libxtp/settings.cc
@@ -59,46 +59,5 @@ void Settings::add(const std::string& key, const std::string& value) {
   prop.add(key, value);
 }
 
-void Settings::validate() const {
-  std::vector<std::string> keywords = _mandatory_keyword;
-  if (this->get("name") != "xtp") {
-    this->check_mandatory_keyword("executable");
-  }
-  for (const auto& x : keywords) {
-    this->check_mandatory_keyword(x);
-  }
-  std::stringstream stream;
-  // Check that the input keys are valid
-  for (const auto& pair : this->_nodes) {
-    auto it = std::find(this->_general_properties.cbegin(),
-                        this->_general_properties.cend(), pair.first);
-
-    if (it == this->_general_properties.cend()) {
-      stream << "Unrecognized keyword \"" << pair.first << "\"\n"
-             << "Keywords must be one of the following:\n";
-      for (const std::string& key : this->_general_properties) {
-        stream << key << "\n";
-      }
-      throw std::runtime_error(stream.str());
-    }
-  }
-}
-
-void Settings::check_mandatory_keyword(const std::string& key) const {
-  std::stringstream stream;
-  auto it = this->_nodes.find(key);
-  if (it == this->_nodes.end()) {
-    stream << "the " << key << " keyword is mandatory\n";
-    auto it2 = this->_keyword_options.find(key);
-    if (it2 != this->_keyword_options.end()) {
-      stream << key << "must be one of the following values:\n";
-      for (const auto& x : it2->second) {
-        stream << x << "\n";
-      }
-    }
-    throw std::runtime_error(stream.str());
-  }
-}
-
 }  // namespace xtp
 }  // namespace votca

--- a/src/tests/test_settings.cc
+++ b/src/tests/test_settings.cc
@@ -87,7 +87,6 @@ BOOST_AUTO_TEST_CASE(test_amend) {
   Settings user_input("package");
   user_input.load_from_xml("user_input.xml");
   user_input.amend(qmpackage_template);
-  user_input.validate();
 
   auto basisset = user_input.get("functional");
   auto ecp = user_input.get("ecp");


### PR DESCRIPTION
## Changes
Allow user to use the `dftpackage` and `gwbse_options` defaults by omiting those sections.