### PR TITLE
Make options file optional for xtp_run

### DIFF
--- a/share/xtp/xml/eanalyze.xml
+++ b/share/xtp/xml/eanalyze.xml
@@ -1,12 +1,10 @@
 <options>
 
 <eanalyze help="Histogram and correlation function of site energies and pair energy differences" section="sec:eanalyze">
-
-	<resolution_sites help="Bin size for site energy histogram" unit="eV">0.01</resolution_sites>
-	<resolution_pairs help="Bin size for pair energy histogram" unit="eV">0.01</resolution_pairs>
-	<resolution_space help="Bin size for site energy correlation" unit="eV">0.01</resolution_space>
-	<states help="states to analyze e,h,s,t">e h s t</states>
-
+	<resolution_sites help="Bin size for site energy histogram" unit="eV" default="0.01">0.01</resolution_sites>
+	<resolution_pairs help="Bin size for pair energy histogram" unit="eV" default="0.01">0.01</resolution_pairs>
+	<resolution_spatial help="Bin size for site energy correlation" unit="eV" default="0.01">0.01</resolution_spatial>
+	<states help="states to analyze" default="e h s t">e h s t</states>
 </eanalyze>
 
 </options>

--- a/share/xtp/xml/ianalyze.xml
+++ b/share/xtp/xml/ianalyze.xml
@@ -1,9 +1,9 @@
 <options>
 
 <ianalyze help="Evaluates a histogram of a logarithm of squared couplings" section="sec:ianalyze">
-	<resolution_logJ2 help="Bin size of histogram log(J2)">0.5</resolution_logJ2>
-	<resolution_space help="Bin size for r in log(J2(r))" unit="nm">0.05</resolution_space>
-	<states help="States for which to calculate the histogram.">e h s t</states>
+	<resolution_logJ2 help="Bin size of histogram log(J2)" default="0.5">0.5</resolution_logJ2>
+	<resolution_space help="Bin size for r in log(J2(r))" unit="nm" default="0.05">0.05</resolution_space>
+	<states help="States for which to calculate the histogram" default="e h s t">e h s t</states>
 </ianalyze>
 
 </options>

--- a/share/xtp/xml/kmclifetime.xml
+++ b/share/xtp/xml/kmclifetime.xml
@@ -2,16 +2,16 @@
     <kmclifetime help="Kinetic Monte Carlo simulations of singlets with decay" label="calc:kmclifetime" section="sec:kmc">
         <numberofinsertions>4000</numberofinsertions>
         <seed help="Integer to initialise the random number generator" unit="integer" default=>23</seed>
-        <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer">1</numberofcarriers>
-        <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site.">*</injectionpattern>
-        <lifetimefile help="File from which lifetimes are read in.">lifetimes.xml</lifetimefile>
-        <temperature help="Temperature in Kelvin.">300</temperature>
+        <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer" default=1>1</numberofcarriers>
+        <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site." default="*">*</injectionpattern>
+        <lifetimefile help="File from which lifetimes are read in." default="lifetimes.xml">lifetimes.xml</lifetimefile>
+        <temperature help="Temperature in Kelvin." unit="kelvin" default=300>300</temperature>
         <trajectoryfile help="Name of the trajectory file" unit="">run1.csv</trajectoryfile>
         <carrierenergy help="Run a single carrier at the same time and records its energy">
-	        <run help="Switch on/off">0</run>
-	        <outputfile help="File to write energies to">energies.csv</outputfile>
-	        <alpha help="Smoothing energy profile">0.05</alpha>
-	        <outputsteps help="Write to file every x steps">10</outputsteps>
+	        <run help="Switch on/off" default="0">0</run>
+	        <outputfile help="File to write energies to" default="energies.csv">energies.csv</outputfile>
+	        <alpha help="Smoothing energy profile" default="0.05">0.05</alpha>
+	        <outputsteps help="Write to file every x steps" default="10">10</outputsteps>
         </carrierenergy>
     </kmclifetime>
 </options>

--- a/share/xtp/xml/kmclifetime.xml
+++ b/share/xtp/xml/kmclifetime.xml
@@ -1,7 +1,7 @@
 <options>
     <kmclifetime help="Kinetic Monte Carlo simulations of singlets with decay" label="calc:kmclifetime" section="sec:kmc">
         <numberofinsertions>4000</numberofinsertions>
-        <seed help="Integer to initialise the random number generator" unit="integer">23</seed>
+        <seed help="Integer to initialise the random number generator" unit="integer" default=>23</seed>
         <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer">1</numberofcarriers>
         <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site.">*</injectionpattern>
         <lifetimefile help="File from which lifetimes are read in.">lifetimes.xml</lifetimefile>

--- a/share/xtp/xml/kmclifetime.xml
+++ b/share/xtp/xml/kmclifetime.xml
@@ -1,11 +1,11 @@
 <options>
     <kmclifetime help="Kinetic Monte Carlo simulations of singlets with decay" label="calc:kmclifetime" section="sec:kmc">
         <numberofinsertions>4000</numberofinsertions>
-        <seed help="Integer to initialise the random number generator" unit="integer" default=>23</seed>
-        <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer" default=1>1</numberofcarriers>
+        <seed help="Integer to initialise the random number generator" unit="integer" default=23>23</seed>
+        <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer" default="1">1</numberofcarriers>
         <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site." default="*">*</injectionpattern>
         <lifetimefile help="File from which lifetimes are read in." default="lifetimes.xml">lifetimes.xml</lifetimefile>
-        <temperature help="Temperature in Kelvin." unit="kelvin" default=300>300</temperature>
+        <temperature help="Temperature in Kelvin." unit="kelvin" default="300">300</temperature>
         <trajectoryfile help="Name of the trajectory file" unit="">run1.csv</trajectoryfile>
         <carrierenergy help="Run a single carrier at the same time and records its energy">
 	        <run help="Switch on/off" default="0">0</run>

--- a/share/xtp/xml/kmcmultiple.xml
+++ b/share/xtp/xml/kmcmultiple.xml
@@ -2,14 +2,14 @@
 
     <kmcmultiple help="Kinetic Monte Carlo simulations of multiple holes or electrons in periodic boundary conditions" label="calc:kmcmultiple" section="sec:kmc">
 
-	    <runtime help="Simulated time in seconds (if a number smaller than 100 is given) or number of KMC steps (if a number larger than 100 is given)" unit="seconds or integer" default="">1E-4</runtime>
+	    <runtime help="Simulated time in seconds (if a number smaller than 100 is given) or number of KMC steps (if a number larger than 100 is given)" unit="seconds or integer" default="1e-4">1E-4</runtime>
 	    <outputtime help="Time difference between outputs into the trajectory file. Set to 0 if you wish to have no trajectory written out." unit="seconds" default="1E-8">1E-8</outputtime>
 	    <trajectoryfile help="Name of the trajectory file" unit="" default="trajectory.csv">trajectory.csv</trajectoryfile>
 	    <seed help="Integer to initialise the random number generator" unit="integer" default="123">123</seed>
 	    <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site." unit="" default="*">*</injectionpattern>
 	    <injectionmethod help="Options: random/equilibrated. random: injection sites are selected randomly (generally the recommended option); equilibrated: sites are chosen such that the expected energy per carrier is matched, possibly speeding up convergence" unit="" default="random">random</injectionmethod>
 	    <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer" default="1">1</numberofcarriers>
-	    <field help="external electric field" unit="V/m" default="0">0 0 1e6</field>
+	    <field help="external electric field" unit="V/m" default="0">0</field>
 	    <carriertype help="Options: electron/hole/singlet/triplet. Specifies the carrier type of the transport under consideration." unit="" default="electron">electron</carriertype>
 	    <temperature help="Temperature in Kelvin." unit="Kelvin" default="300">300</temperature>
     </kmcmultiple>

--- a/share/xtp/xml/kmcmultiple.xml
+++ b/share/xtp/xml/kmcmultiple.xml
@@ -9,7 +9,7 @@
 	    <injectionpattern help="Name pattern that specifies on which sites injection is possible. Use the wildcard '*' to inject on any site." unit="" default="*">*</injectionpattern>
 	    <injectionmethod help="Options: random/equilibrated. random: injection sites are selected randomly (generally the recommended option); equilibrated: sites are chosen such that the expected energy per carrier is matched, possibly speeding up convergence" unit="" default="random">random</injectionmethod>
 	    <numberofcarriers help="Number of electrons/holes in the simulation box" unit="integer" default="1">1</numberofcarriers>
-	    <field help="external electric field" unit="V/m" default="0">0</field>
+	    <field help="external electric field" unit="V/m" default="0.0 0.0 0.0">0.0 0.0 0.0</field>
 	    <carriertype help="Options: electron/hole/singlet/triplet. Specifies the carrier type of the transport under consideration." unit="" default="electron">electron</carriertype>
 	    <temperature help="Temperature in Kelvin." unit="Kelvin" default="300">300</temperature>
     </kmcmultiple>

--- a/share/xtp/xml/mapchecker.xml
+++ b/share/xtp/xml/mapchecker.xml
@@ -1,9 +1,12 @@
 <options>
 
 <mapchecker help="Outputs .pdb files for segments, qmmolecules and classical segments to check the mapping" section="sec:mapchecker">
-    <qm_states help="qmstates states to check">n</qm_states>
-    <mp_states help="multipole states to check">e h</mp_states>
-    <map_file help="xml file with segment definition">system.xml</map_file>
+    <qm_states help="qmstates states to check" default="n">n</qm_states>
+    <mp_states help="multipole states to check" default=" e h">e h</mp_states>
+    <map_file help="xml file with segment definition" default="votca_map.xml">votca_map.xml</map_file>
+    <md_pdbfile help="PDB file with the MD calculation" default="md_segments.pdb">md_segments.pdb<md_pdbfile>
+    <qm_pdbfile help="PDB file with the QM calculation" default="qm_segments.pdb">qm_segments.pdb</qm_pdbfile>
+    <mp_pdbfile help="PDB file with the MP segments" default="mp_segments.pdb">mp_segments.pdb</mp_pdbfile>
 </mapchecker>
 
 </options>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,9 +1,5 @@
 <options>
 <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
-        <segments help="cutoff distances for certain segments identified by name">
-                <type help="segment name1 segment_name2" default="DCV5T_ME3 DCV5T_ME3">DCV5T_ME3 DCV5T_ME3</type>
-                <cutoff unit="nm" default="3">3</cutoff>
-        </segments>
         <constant  help="cutoff for all other types of pairs" unit="nm" default="1.5">1.5</constant>
 </neighborlist>
 </options>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,6 +1,5 @@
 <options>
 
-
 <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
         <segments help="cutoff distances for certain segments identified by name">
                 <type help="segment name1 segment_name2">DCV5T_ME3 DCV5T_ME3</type>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,11 +1,9 @@
 <options>
-
 <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
         <segments help="cutoff distances for certain segments identified by name">
-                <type help="segment name1 segment_name2">DCV5T_ME3 DCV5T_ME3</type>
-                <cutoff unit="nm">3</cutoff>
+                <type help="segment name1 segment_name2" default="DCV5T_ME3 DCV5T_ME3">DCV5T_ME3 DCV5T_ME3</type>
+                <cutoff unit="nm" default="3">3</cutoff>
         </segments>
-        <constant  help="cutoff for all other types of pairs" unit="nm">1.5</constant>
-        <exciton_cutoff help="cutoff beyond which pairs are only treated as singlet transition charges" unit="nm">0.5</exciton_cutoff>
+        <constant  help="cutoff for all other types of pairs" unit="nm" default="1.5">1.5</constant>
 </neighborlist>
 </options>

--- a/share/xtp/xml/vaverage.xml
+++ b/share/xtp/xml/vaverage.xml
@@ -1,6 +1,6 @@
 <options><vaverage>
-    <ratefile help="file with kmc rates from kmcmultiple">rates.dat</ratefile>
-    <occfile help="file with site occupations from kmcmultiple">occupation.dat</occfile>
-    <outputfile help="outputfile">velocities.dat</outputfile>
+    <ratefile help="file with kmc rates from kmcmultiple" default="rates.dat">rates.dat</ratefile>
+    <occfile help="file with site occupations from kmcmultiple" default="occupation.dat">occupation.dat</occfile>
+    <outputfile help="outputfile" default="velocities.dat">velocities.dat</outputfile>
 </vaverage>
 </options>

--- a/src/libxtp/calculators/eanalyze.cc
+++ b/src/libxtp/calculators/eanalyze.cc
@@ -22,8 +22,6 @@ namespace xtp {
 
 void EAnalyze::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _resolution_pairs = _options.get(".resolution_pairs").as<double>();

--- a/src/libxtp/calculators/eanalyze.cc
+++ b/src/libxtp/calculators/eanalyze.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,59 +17,42 @@
 
 #include "eanalyze.h"
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 
-void EAnalyze::Initialize(tools::Property &opt) {
+void EAnalyze::Initialize(tools::Property &user_options) {
 
-  // update options with the VOTCASHARE defaults
-  UpdateWithDefaults(opt, "xtp");
-  std::string key = "options." + Identify();
-  if (opt.exists(key + ".resolution_pairs")) {
-    _resolution_pairs = opt.get(key + ".resolution_pairs").as<double>();
-  } else {
-    _skip_pairs = true;
-  }
-  if (opt.exists(key + ".resolution_sites")) {
-    _resolution_sites = opt.get(key + ".resolution_sites").as<double>();
-  } else {
-    _skip_sites = true;
-  }
-  if (opt.exists(key + ".resolution_space")) {
-    _resolution_space = opt.get(key + ".resolution_space").as<double>();
-  } else {
-    _skip_corr = true;
-  }
+  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml
+  LoadDefaults("xtp");
+  // update options with user specified input
+  UpdateWithUserOptions(user_options);
 
-  if (opt.exists(key + ".pattern")) {
-    _seg_pattern = opt.get(key + ".pattern").as<std::string>();
+  _resolution_pairs = _options.get(".resolution_pairs").as<double>();
+  _resolution_sites = _options.get(".resolution_sites").as<double>();
+  _resolution_spatial = _options.get(".resolution_spatial").as<double>();
+
+  if (_options.exists(".pattern")) {
+    _seg_pattern = _options.get(".pattern").as<std::string>();
   } else {
     _seg_pattern = "*";
   }
 
-  if (opt.exists(key + ".states")) {
-    std::string statestrings = opt.get(key + ".states").as<std::string>();
-    tools::Tokenizer tok(statestrings, ",\n\t ");
-    std::vector<std::string> string_vec;
-    tok.ToVector(string_vec);
-    for (std::string &state : string_vec) {
-      _states.push_back(QMStateType(state));
-    }
-  } else {
-    _states.push_back(QMStateType::Electron);
-    _states.push_back(QMStateType::Hole);
+  std::string statestrings = _options.get(".states").as<std::string>();
+  tools::Tokenizer tok(statestrings, ",\n\t ");
+  std::vector<std::string> string_vec;
+  tok.ToVector(string_vec);
+  for (std::string &state : string_vec) {
+    _states.push_back(QMStateType(state));
   }
 
-  _doenergy_landscape = opt.ifExistsReturnElseReturnDefault<bool>(
-      key + ".energy_landscape", false);
+  _doenergy_landscape = _options.ifExistsReturnElseReturnDefault<bool>(
+      ".energy_landscape", false);
 
-  if (opt.exists(key + ".distancemode")) {
+  if (_options.exists(".distancemode")) {
     std::vector<std::string> choices = {"atoms", "centerofmass"};
     std::string distancemode =
-        opt.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
-            key + ".distancemode", choices);
+        _options.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
+            ".distancemode", choices);
     if (distancemode == "centerofmass") {
       _atomdistances = false;
     } else {
@@ -116,30 +99,15 @@ bool EAnalyze::EvaluateFrame(Topology &top) {
                 << "... ... ... No segments short-listed. Skip ... "
                 << std::flush;
     } else {
-      if (_skip_sites) {
-        std::cout << std::endl
-                  << "... ... ... Skip site-energy hist." << std::flush;
-      } else {
-        SiteHist(state);
-      }
-      if (_skip_corr) {
-        std::cout << std::endl
-                  << "... ... ... Skip correlation ..." << std::flush;
-      } else {
-        SiteCorr(top, state);
-      }
+      SiteHist(state);
+      SiteCorr(top, state);
     }
 
     if (!nblist.size()) {
       std::cout << std::endl
                 << "... ... ... No pairs in topology. Skip ... " << std::flush;
     } else {
-      if (_skip_pairs) {
-        std::cout << std::endl
-                  << "... ... ... Skip pair-energy hist." << std::flush;
-      } else {
-        PairHist(top, state);
-      }
+      PairHist(top, state);
     }
   }
 
@@ -292,12 +260,12 @@ void EAnalyze::SiteCorr(const Topology &top, QMStateType state) const {
   double MAX = tabcorr.x().maxCoeff();
 
   // Prepare bins
-  Index BIN = Index((MAX - MIN) / _resolution_space + 0.5) + 1;
+  Index BIN = Index((MAX - MIN) / _resolution_spatial + 0.5) + 1;
   std::vector<std::vector<double> > histCs;
   histCs.resize(BIN);
 
   for (Index i = 0; i < tabcorr.size(); ++i) {
-    Index bin = Index((tabcorr.x()[i] - MIN) / _resolution_space + 0.5);
+    Index bin = Index((tabcorr.x()[i] - MIN) / _resolution_spatial + 0.5);
     histCs[bin].push_back(tabcorr.y()[i]);
   }
 
@@ -319,7 +287,7 @@ void EAnalyze::SiteCorr(const Topology &top, QMStateType state) const {
     // error on mean value
     dcorr2 =
         dcorr2 / double(histCs[bin].size()) / double(histCs[bin].size() - 1);
-    double R = MIN + double(bin) * _resolution_space;
+    double R = MIN + double(bin) * _resolution_spatial;
     histC.set(bin, R, corr, ' ', std::sqrt(dcorr2));
   }
 

--- a/src/libxtp/calculators/eanalyze.cc
+++ b/src/libxtp/calculators/eanalyze.cc
@@ -22,10 +22,9 @@ namespace xtp {
 
 void EAnalyze::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _resolution_pairs = _options.get(".resolution_pairs").as<double>();
   _resolution_sites = _options.get(".resolution_sites").as<double>();

--- a/src/libxtp/calculators/eanalyze.h
+++ b/src/libxtp/calculators/eanalyze.h
@@ -51,14 +51,10 @@ class EAnalyze : public QMCalculator {
 
   double _resolution_pairs;
   double _resolution_sites;
-  double _resolution_space;
+  double _resolution_spatial;
   bool _atomdistances = false;
 
   std::vector<QMStateType> _states;
-
-  bool _skip_corr = false;
-  bool _skip_sites = false;
-  bool _skip_pairs = false;
 
   bool _doenergy_landscape;
   Index _first_seg;

--- a/src/libxtp/calculators/einternal.cc
+++ b/src/libxtp/calculators/einternal.cc
@@ -24,10 +24,9 @@ namespace xtp {
 
 void EInternal::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/einternal.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // get pre-defined default options from VOTCASHARE/xtp/xml/einternal.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _energiesXML =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".energiesXML");

--- a/src/libxtp/calculators/einternal.cc
+++ b/src/libxtp/calculators/einternal.cc
@@ -24,7 +24,7 @@ namespace xtp {
 
 void EInternal::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml
+  // get pre-defined default options from VOTCASHARE/xtp/xml/einternal.xml
   LoadDefaults("xtp");
   // update options with user specified input
   UpdateWithUserOptions(user_options);

--- a/src/libxtp/calculators/einternal.cc
+++ b/src/libxtp/calculators/einternal.cc
@@ -24,8 +24,6 @@ namespace xtp {
 
 void EInternal::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/einternal.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _energiesXML =

--- a/src/libxtp/calculators/einternal.cc
+++ b/src/libxtp/calculators/einternal.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,23 +19,23 @@
 
 #include <votca/xtp/topology.h>
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 
-void EInternal::Initialize(tools::Property &options) {
-  std::string key = "options." + Identify();
+void EInternal::Initialize(tools::Property &user_options) {
 
-  _energiesXML = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".energiesXML");
+  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml
+  LoadDefaults("xtp");
+  // update options with user specified input
+  UpdateWithUserOptions(user_options);
+
+  _energiesXML =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".energiesXML");
 }
 
 void EInternal::ParseEnergies() {
 
-  std::cout << std::endl
-            << "... ... Site, reorg. energies from " << _energiesXML << ". "
-            << std::flush;
+  std::cout << "\n... ... Site, reorg. energies from " << _energiesXML << ".\n";
 
   tools::Property alloc;
   alloc.LoadFromXML(_energiesXML);

--- a/src/libxtp/calculators/einternal.h
+++ b/src/libxtp/calculators/einternal.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,33 +22,28 @@
 #include <votca/tools/histogramnew.h>
 #include <votca/xtp/topology.h>
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 
-void IAnalyze::Initialize(tools::Property &opt) {
-  std::cout << std::endl;
-  _do_pairtype = false;
-  _do_IRdependence = false;
-  std::string key = "options." + Identify();
-  if (opt.exists(key + ".states")) {
-    std::string statestrings = opt.get(key + ".states").as<std::string>();
-    tools::Tokenizer tok(statestrings, ",\n\t ");
-    std::vector<std::string> string_vec;
-    tok.ToVector(string_vec);
-    for (std::string &state : string_vec) {
-      _states.push_back(QMStateType(state));
-    }
-  } else {
-    _states.push_back(QMStateType(QMStateType::Electron));
-    _states.push_back(QMStateType(QMStateType::Hole));
+void IAnalyze::Initialize(tools::Property &user_options) {
+
+  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml
+  LoadDefaults("xtp");
+  // update options with user specified input
+  UpdateWithUserOptions(user_options);
+
+  std::string statestrings = _options.get(".states").as<std::string>();
+  tools::Tokenizer tok(statestrings, ",\n\t ");
+  std::vector<std::string> string_vec;
+  tok.ToVector(string_vec);
+  for (std::string &state : string_vec) {
+    _states.push_back(QMStateType(state));
   }
 
-  _resolution_logJ2 = opt.get(key + ".resolution_logJ2").as<double>();
-  if (opt.exists(key + ".pairtype")) {
+  _resolution_logJ2 = _options.get(".resolution_logJ2").as<double>();
+  if (_options.exists(".pairtype")) {
     _do_pairtype = true;
-    std::string _store_stdstring = opt.get(key + ".pairtype").as<std::string>();
+    std::string _store_stdstring = _options.get(".pairtype").as<std::string>();
     if (_store_stdstring.find("Hopping") != std::string::npos) {
       _pairtype.push_back(QMPair::Hopping);
     }
@@ -56,14 +51,13 @@ void IAnalyze::Initialize(tools::Property &opt) {
       _pairtype.push_back(QMPair::Excitoncl);
     }
     if (!_pairtype.size()) {
-      std::cout << std::endl
-                << "... ... No pairtypes recognized will output all pairs. ";
+      std::cout << "\n... ... No pairtypes recognized will output all pairs. ";
       _do_pairtype = false;
     }
   }
-  if (opt.exists(key + ".resolution_space")) {
-    _resolution_space = opt.get(key + ".resolution_space").as<double>();
-    if (_resolution_space != 0.0) {
+  if (_options.exists(".resolution_spatial")) {
+    _resolution_spatial = _options.get(".resolution_spatial").as<double>();
+    if (_resolution_spatial != 0.0) {
       _do_IRdependence = true;
     }
   }
@@ -182,14 +176,14 @@ void IAnalyze::IRdependence(Topology &top, QMStateType state) {
   double MINR = *std::min_element(distances.begin(), distances.end());
 
   // Prepare R bins
-  Index pointsR = Index((MAXR - MINR) / _resolution_space);
+  Index pointsR = Index((MAXR - MINR) / _resolution_spatial);
   std::vector<std::vector<double> > rJ2;
   rJ2.resize(pointsR);
 
   // Loop over distance
   for (Index i = 0; i < pointsR; ++i) {
-    double thisMINR = MINR + double(i) * _resolution_space;
-    double thisMAXR = MINR + double(i + 1) * _resolution_space;
+    double thisMINR = MINR + double(i) * _resolution_spatial;
+    double thisMAXR = MINR + double(i + 1) * _resolution_spatial;
     // now count Js that lie within this R range
     for (Index j = 0; j < Index(J2s.size()); ++j) {
       if (thisMINR < distances[j] && distances[j] < thisMAXR) {
@@ -207,7 +201,7 @@ void IAnalyze::IRdependence(Topology &top, QMStateType state) {
     const std::vector<double> &vec = rJ2[i];
     double sum = std::accumulate(vec.begin(), vec.end(), 0.0);
     double AVG = sum / double(vec.size());
-    double thisR = MINR + (double(i) + 0.5) * _resolution_space;
+    double thisR = MINR + (double(i) + 0.5) * _resolution_spatial;
     double sq_sum =
         std::inner_product(vec.begin(), vec.end(), vec.begin(), 0.0);
     double STD = std::sqrt(sq_sum / double(vec.size()) - AVG * AVG);

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -27,7 +27,7 @@ namespace xtp {
 
 void IAnalyze::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/eanalyze.xml
+  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml
   LoadDefaults("xtp");
   // update options with user specified input
   UpdateWithUserOptions(user_options);

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -27,10 +27,9 @@ namespace xtp {
 
 void IAnalyze::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   std::string statestrings = _options.get(".states").as<std::string>();
   tools::Tokenizer tok(statestrings, ",\n\t ");

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -27,8 +27,6 @@ namespace xtp {
 
 void IAnalyze::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/ianalyze.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   std::string statestrings = _options.get(".states").as<std::string>();

--- a/src/libxtp/calculators/ianalyze.h
+++ b/src/libxtp/calculators/ianalyze.h
@@ -39,10 +39,10 @@ class IAnalyze : public QMCalculator {
  private:
   double _resolution_logJ2;
   std::vector<QMStateType> _states;
-  double _resolution_space;
+  double _resolution_spatial;
   std::vector<QMPair::PairType> _pairtype;
-  bool _do_pairtype;
-  bool _do_IRdependence;
+  bool _do_pairtype = false;
+  bool _do_IRdependence = false;
 };
 
 }  // namespace xtp

--- a/src/libxtp/calculators/ianalyze.h
+++ b/src/libxtp/calculators/ianalyze.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/libxtp/calculators/kmclifetime.cc
+++ b/src/libxtp/calculators/kmclifetime.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libxtp/calculators/kmclifetime.cc
+++ b/src/libxtp/calculators/kmclifetime.cc
@@ -19,58 +19,52 @@
 #include "votca/xtp/qmstate.h"
 #include <boost/format.hpp>
 #include <boost/progress.hpp>
-#include <locale>
 #include <votca/tools/constants.h>
 #include <votca/tools/property.h>
 #include <votca/xtp/eigen.h>
 #include <votca/xtp/gnode.h>
 #include <votca/xtp/topology.h>
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 
-void KMCLifetime::Initialize(tools::Property& options) {
+void KMCLifetime::Initialize(tools::Property& user_options) {
 
-  std::string key = "options." + Identify();
-  ParseCommonOptions(options);
-  _insertions = options.ifExistsReturnElseThrowRuntimeError<unsigned long>(
-      key + ".numberofinsertions");
+  // get pre-defined default options from VOTCASHARE/xtp/xml/kmclifetime.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
-  _lifetimefile = options.ifExistsReturnElseThrowRuntimeError<string>(
-      key + ".lifetimefile");
+  _insertions = _options.ifExistsReturnElseThrowRuntimeError<unsigned long>(
+      ".numberofinsertions");
 
-  _probfile = options.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".decayprobfile", "");
+  _lifetimefile = _options.ifExistsReturnElseThrowRuntimeError<std::string>(
+      ".lifetimefile");
 
-  std::string subkey = key + ".carrierenergy";
-  if (options.exists(subkey)) {
-    _do_carrierenergy =
-        options.ifExistsReturnElseReturnDefault<bool>(subkey + ".run", false);
-    _energy_outputfile = options.ifExistsReturnElseReturnDefault<std::string>(
-        subkey + ".outputfile", "energy.tab");
-    _alpha =
-        options.ifExistsReturnElseReturnDefault<double>(subkey + ".alpha", 0.3);
-    _outputsteps = options.ifExistsReturnElseReturnDefault<unsigned long>(
-        subkey + ".outputsteps", 100);
+  _probfile = _options.ifExistsReturnElseReturnDefault<std::string>(
+      ".decayprobfile", "");
 
-  } else {
-    _do_carrierenergy = false;
-  }
+  tools::Property& carrier_options = _options.get(".carrierenergy");
+  _do_carrierenergy =
+      carrier_options.ifExistsReturnElseThrowRuntimeError<bool>(".run");
+  _energy_outputfile =
+      carrier_options.ifExistsReturnElseThrowRuntimeError<std::string>(
+          ".outputfile");
+  _alpha =
+      carrier_options.ifExistsReturnElseThrowRuntimeError<double>(".alpha");
+  _outputsteps =
+      carrier_options.ifExistsReturnElseThrowRuntimeError<unsigned long>(
+          ".outputsteps");
 
   _log.setReportLevel(Log::current_level);
   _log.setCommonPreface("\n ...");
 
   _carriertype = QMStateType(QMStateType::Singlet);
   XTP_LOG(Log::error, _log)
-      << "carrier type:" << _carriertype.ToLongString() << flush;
+      << "carrier type:" << _carriertype.ToLongString() << std::flush;
   _field = Eigen::Vector3d::Zero();
-
-  return;
 }
 
-void KMCLifetime::WriteDecayProbability(string filename) {
+void KMCLifetime::WriteDecayProbability(std::string filename) {
 
   Eigen::VectorXd outrates = Eigen::VectorXd::Zero(_nodes.size());
   Eigen::VectorXd inrates = Eigen::VectorXd::Zero(_nodes.size());
@@ -92,12 +86,12 @@ void KMCLifetime::WriteDecayProbability(string filename) {
   outrates = decayrates.cwiseQuotient(outrates + decayrates);
   inrates = decayrates.cwiseQuotient(inrates + decayrates);
 
-  fstream probs;
-  probs.open(filename, fstream::out);
-  probs << "#SiteID, Relative Prob outgoing, Relative Prob ingoing" << endl;
+  std::fstream probs;
+  probs.open(filename, std::fstream::out);
+  probs << "#SiteID, Relative Prob outgoing, Relative Prob ingoing\n";
   for (unsigned i = 0; i < _nodes.size(); i++) {
     probs << _nodes[i].getId() << " " << outrates[i] << " " << inrates[i]
-          << endl;
+          << std::endl;
   }
   probs.close();
   return;
@@ -108,7 +102,7 @@ void KMCLifetime::ReadLifetimeFile(std::string filename) {
   xml.LoadFromXML(filename);
   std::vector<tools::Property*> jobProps = xml.Select("lifetimes.site");
   if (jobProps.size() != _nodes.size()) {
-    throw runtime_error(
+    throw std::runtime_error(
         (boost::format("The number of sites in the topology: %i does not match "
                        "the number in the lifetimefile: %i") %
          _nodes.size() % jobProps.size())
@@ -125,13 +119,13 @@ void KMCLifetime::ReadLifetimeFile(std::string filename) {
         check = true;
         break;
       } else if (node.getId() == site_id && node.canDecay()) {
-        throw runtime_error(
+        throw std::runtime_error(
             (boost::format("Node %i appears twice in your list") % site_id)
                 .str());
       }
     }
     if (!check) {
-      throw runtime_error(
+      throw std::runtime_error(
           (boost::format("Site from file with id: %i not found in state file") %
            site_id)
               .str());
@@ -144,7 +138,7 @@ void KMCLifetime::ReadLifetimeFile(std::string filename) {
   return;
 }
 
-void KMCLifetime::WriteToTraj(fstream& traj, unsigned long insertioncount,
+void KMCLifetime::WriteToTraj(std::fstream& traj, unsigned long insertioncount,
                               double simtime,
                               const Chargecarrier& affectedcarrier) const {
   const Eigen::Vector3d& dr_travelled = affectedcarrier.get_dRtravelled();
@@ -154,7 +148,7 @@ void KMCLifetime::WriteToTraj(fstream& traj, unsigned long insertioncount,
        << affectedcarrier.getCurrentNodeId() + 1 << "\t"
        << dr_travelled.x() * tools::conv::bohr2nm << "\t"
        << dr_travelled.y() * tools::conv::bohr2nm << "\t"
-       << dr_travelled.z() * tools::conv::bohr2nm << endl;
+       << dr_travelled.z() * tools::conv::bohr2nm << std::endl;
 }
 
 void KMCLifetime::RunVSSM() {
@@ -163,38 +157,38 @@ void KMCLifetime::RunVSSM() {
   XTP_LOG(Log::error, _log)
       << "\nAlgorithm: VSSM for Multiple Charges with finite Lifetime\n"
          "number of charges: "
-      << _numberofcarriers << "\nnumber of nodes: " << _nodes.size() << flush;
+      << _numberofcarriers << "\nnumber of nodes: " << _nodes.size()
+      << std::flush;
 
   if (_numberofcarriers > Index(_nodes.size())) {
-    throw runtime_error(
+    throw std::runtime_error(
         "ERROR in kmclifetime: specified number of charges is greater than the "
         "number of nodes. This conflicts with single occupation.");
   }
 
-  fstream traj;
-  fstream energyfile;
+  std::fstream traj;
+  std::fstream energyfile;
 
   XTP_LOG(Log::error, _log)
-      << "Writing trajectory to " << _trajectoryfile << "." << flush;
-  traj.open(_trajectoryfile, fstream::out);
+      << "Writing trajectory to " << _trajectoryfile << "." << std::flush;
+  traj.open(_trajectoryfile, std::fstream::out);
   traj << "#Simtime [s]\t Insertion\t Carrier ID\t Lifetime[s]\tSteps\t Last "
-          "Segment\t x_travelled[nm]\t y_travelled[nm]\t z_travelled[nm]"
-       << endl;
+          "Segment\t x_travelled[nm]\t y_travelled[nm]\t z_travelled[nm]\n";
 
   if (_do_carrierenergy) {
 
     XTP_LOG(Log::error, _log)
         << "Tracking the energy of one charge carrier and exponential average "
            "with alpha="
-        << _alpha << " to " << _energy_outputfile << flush;
-    energyfile.open(_energy_outputfile, fstream::out);
+        << _alpha << " to " << _energy_outputfile << std::flush;
+    energyfile.open(_energy_outputfile, std::fstream::out);
     energyfile << "Simtime [s]\tSteps\tCarrier ID\tEnergy_a=" << _alpha
-               << "[eV]" << endl;
+               << "[eV]\n";
   }
 
   // Injection
   XTP_LOG(Log::error, _log)
-      << "\ninjection method: " << _injectionmethod << flush;
+      << "\ninjection method: " << _injectionmethod << std::flush;
 
   RandomlyCreateCharges();
 
@@ -207,7 +201,8 @@ void KMCLifetime::RunVSSM() {
 
   time_t now = time(nullptr);
   tm* localtm = localtime(&now);
-  XTP_LOG(Log::error, _log) << "Run started at " << asctime(localtm) << flush;
+  XTP_LOG(Log::error, _log)
+      << "Run started at " << asctime(localtm) << std::flush;
 
   double avlifetime = 0.0;
   double meanfreepath = 0.0;
@@ -222,7 +217,7 @@ void KMCLifetime::RunVSSM() {
           << "\nReal time limit of " << _maxrealtime << " hours ("
           << Index(_maxrealtime * 60 * 60 + 0.5)
           << " seconds) has been reached. Stopping here.\n"
-          << flush;
+          << std::flush;
       break;
     }
 
@@ -233,7 +228,7 @@ void KMCLifetime::RunVSSM() {
     }
     if (cumulated_rate == 0) {  // this should not happen: no possible jumps
                                 // defined for a node
-      throw runtime_error(
+      throw std::runtime_error(
           "ERROR in kmclifetime: Incorrect rates in the database file. All the "
           "escape rates for the current setting are 0.");
     }
@@ -253,7 +248,7 @@ void KMCLifetime::RunVSSM() {
       }
       if (print) {
         energyfile << simtime << "\t" << step << "\t" << _carriers[0].getId()
-                   << "\t" << avgenergy * tools::conv::hrt2ev << endl;
+                   << "\t" << avgenergy * tools::conv::hrt2ev << std::endl;
       }
     }
 
@@ -350,7 +345,7 @@ void KMCLifetime::RunVSSM() {
       << std::sqrt(difflength_squared.norm() / double(insertioncount)) *
              tools::conv::bohr2nm
       << " nm\n"
-      << flush;
+      << std::flush;
 
   WriteOccupationtoFile(simtime, _occfile);
   traj.close();
@@ -366,7 +361,8 @@ bool KMCLifetime::EvaluateFrame(Topology& top) {
                                "\n-----------------------------------\n"
                             << std::flush;
 
-  XTP_LOG(Log::info, _log) << "\nInitialising random number generator" << flush;
+  XTP_LOG(Log::info, _log) << "\nInitialising random number generator"
+                           << std::flush;
 
   _RandomVariable.init(_seed);
   LoadGraph(top);

--- a/src/libxtp/calculators/kmclifetime.cc
+++ b/src/libxtp/calculators/kmclifetime.cc
@@ -30,8 +30,6 @@ namespace xtp {
 
 void KMCLifetime::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/kmclifetime.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _insertions = _options.ifExistsReturnElseThrowRuntimeError<unsigned long>(

--- a/src/libxtp/calculators/kmclifetime.h
+++ b/src/libxtp/calculators/kmclifetime.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 #define __VOTCA_KMC_LIFETIME_H
 
 #include <votca/xtp/kmccalculator.h>
-using namespace std;
 
 namespace votca {
 namespace xtp {
@@ -38,7 +37,7 @@ class KMCLifetime : public KMCCalculator {
   void WriteDecayProbability(std::string filename);
 
   void RunVSSM() override;
-  void WriteToTraj(fstream& traj, unsigned long insertioncount, double simtime,
+  void WriteToTraj(std::fstream& traj, unsigned long insertioncount, double simtime,
                    const Chargecarrier& carrier) const;
 
   void ReadLifetimeFile(std::string filename);
@@ -54,4 +53,4 @@ class KMCLifetime : public KMCCalculator {
 }  // namespace xtp
 }  // namespace votca
 
-#endif /* __VOTCA_KMC_MULTIPLE_H */
+#endif

--- a/src/libxtp/calculators/kmcmultiple.cc
+++ b/src/libxtp/calculators/kmcmultiple.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,6 @@
 #include <votca/xtp/gnode.h>
 #include <votca/xtp/topology.h>
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 void KMCMultiple::Initialize(tools::Property& options) {
@@ -49,8 +47,8 @@ void KMCMultiple::Initialize(tools::Property& options) {
                                                            "e");
   _carriertype = QMStateType(carriertype);
   if (!_carriertype.isKMCState()) {
-    throw runtime_error("KMC cannot be run for state:" +
-                        _carriertype.ToLongString());
+    throw std::runtime_error("KMC cannot be run for state:" +
+                             _carriertype.ToLongString());
   }
 
   _log.setReportLevel(Log::current_level);
@@ -70,19 +68,19 @@ void KMCMultiple::PrintDiffandMu(const Eigen::Matrix3d& avgdiffusiontensor,
     XTP_LOG(Log::error, _log)
         << "\nStep: " << step
         << " Diffusion tensor averaged over all carriers (nm^2/s):\n"
-        << result * tools::conv::bohr2nm * tools::conv::bohr2nm << flush;
+        << result * tools::conv::bohr2nm * tools::conv::bohr2nm << std::flush;
   } else {
     double average_mobility = 0;
     double bohr2Hrts_to_nm2Vs =
         tools::conv::bohr2nm * tools::conv::bohr2nm / tools::conv::hrt2ev;
-    XTP_LOG(Log::error, _log) << "\nMobilities (nm^2/Vs): " << flush;
+    XTP_LOG(Log::error, _log) << "\nMobilities (nm^2/Vs): " << std::flush;
     for (Index i = 0; i < _numberofcarriers; i++) {
       Eigen::Vector3d velocity = _carriers[i].get_dRtravelled() / simtime;
       double mobility =
           velocity.dot(_field) / (absolute_field * absolute_field);
       XTP_LOG(Log::error, _log)
           << std::scientific << "    carrier " << i + 1
-          << ": mu=" << mobility * bohr2Hrts_to_nm2Vs << flush;
+          << ": mu=" << mobility * bohr2Hrts_to_nm2Vs << std::flush;
       average_mobility +=
           velocity.dot(_field) / (absolute_field * absolute_field);
     }
@@ -90,12 +88,12 @@ void KMCMultiple::PrintDiffandMu(const Eigen::Matrix3d& avgdiffusiontensor,
     XTP_LOG(Log::error, _log)
         << std::scientific
         << "  Overall average mobility in field direction <mu>="
-        << average_mobility * bohr2Hrts_to_nm2Vs << " nm^2/Vs  " << flush;
+        << average_mobility * bohr2Hrts_to_nm2Vs << " nm^2/Vs  " << std::flush;
   }
 }
 
 void KMCMultiple::WriteToTrajectory(std::fstream& traj,
-                                    vector<Eigen::Vector3d>& startposition,
+                                    std::vector<Eigen::Vector3d>& startposition,
                                     double simtime, unsigned long step) const {
   traj << simtime << "\t";
   traj << step << "\t";
@@ -107,7 +105,7 @@ void KMCMultiple::WriteToTrajectory(std::fstream& traj,
     if (i < _numberofcarriers - 1) {
       traj << "\t";
     } else {
-      traj << endl;
+      traj << std::endl;
     }
   }
 }
@@ -138,7 +136,8 @@ void KMCMultiple::WriteToEnergyFile(std::fstream& tfile, double simtime,
         << currentenergy * tools::conv::hrt2ev << "\t"
         << currentmobility * bohr2Hrts_to_nm2Vs << "\t"
         << dr_travelled_field * tools::conv::bohr2nm << "\t"
-        << dr_travelled_current.norm() * tools::conv::bohr2nm << "\t" << endl;
+        << dr_travelled_current.norm() * tools::conv::bohr2nm << "\t"
+        << std::endl;
 }
 
 void KMCMultiple::PrintDiagDandMu(const Eigen::Matrix3d& avgdiffusiontensor,
@@ -151,14 +150,14 @@ void KMCMultiple::PrintDiagDandMu(const Eigen::Matrix3d& avgdiffusiontensor,
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> es;
   es.computeDirect(result);
   double bohr2_nm2 = tools::conv::bohr2nm * tools::conv::bohr2nm;
-  XTP_LOG(Log::error, _log) << "\nEigenvalues:\n " << flush;
+  XTP_LOG(Log::error, _log) << "\nEigenvalues:\n " << std::flush;
   for (Index i = 0; i < 3; i++) {
     XTP_LOG(Log::error, _log)
-        << "Eigenvalue: " << es.eigenvalues()(i) * bohr2_nm2 << flush
+        << "Eigenvalue: " << es.eigenvalues()(i) * bohr2_nm2 << std::flush
         << "Eigenvector: " << es.eigenvectors().col(i).x() << "   "
         << es.eigenvectors().col(i).y() << "   " << es.eigenvectors().col(i).z()
         << "\n"
-        << flush;
+        << std::flush;
   }
   double bohr2Hrts_to_nm2Vs =
       tools::conv::bohr2nm * tools::conv::bohr2nm / tools::conv::hrt2ev;
@@ -167,12 +166,12 @@ void KMCMultiple::PrintDiagDandMu(const Eigen::Matrix3d& avgdiffusiontensor,
     XTP_LOG(Log::error, _log)
         << "The following value is calculated using the Einstein relation "
            "and assuming an isotropic medium"
-        << flush;
+        << std::flush;
     double avgD = 1. / 3. * es.eigenvalues().sum();
     double average_mobility = std::abs(avgD / _temperature);
     XTP_LOG(Log::error, _log)
         << std::scientific << "  Overall average mobility <mu>="
-        << average_mobility * bohr2Hrts_to_nm2Vs << " nm^2/Vs " << flush;
+        << average_mobility * bohr2Hrts_to_nm2Vs << " nm^2/Vs " << std::flush;
   }
 }
 
@@ -183,7 +182,7 @@ void KMCMultiple::PrintChargeVelocity(double simtime) {
         << std::scientific << "    carrier " << i + 1 << ": "
         << _carriers[i].get_dRtravelled().transpose() / simtime *
                tools::conv::bohr2nm
-        << flush;
+        << std::flush;
     avg_dr_travelled += _carriers[i].get_dRtravelled();
   }
   avg_dr_travelled /= double(_numberofcarriers);
@@ -191,17 +190,18 @@ void KMCMultiple::PrintChargeVelocity(double simtime) {
   Eigen::Vector3d avgvelocity = avg_dr_travelled / simtime;
   XTP_LOG(Log::error, _log)
       << std::scientific << "  Overall average velocity (nm/s): "
-      << avgvelocity.transpose() * tools::conv::bohr2nm << flush;
+      << avgvelocity.transpose() * tools::conv::bohr2nm << std::flush;
 }
 
 void KMCMultiple::RunVSSM() {
 
   Index realtime_start = time(nullptr);
   XTP_LOG(Log::error, _log)
-      << "\nAlgorithm: VSSM for Multiple Charges" << flush;
+      << "\nAlgorithm: VSSM for Multiple Charges" << std::flush;
   XTP_LOG(Log::error, _log)
-      << "number of carriers: " << _numberofcarriers << flush;
-  XTP_LOG(Log::error, _log) << "number of nodes: " << _nodes.size() << flush;
+      << "number of carriers: " << _numberofcarriers << std::flush;
+  XTP_LOG(Log::error, _log)
+      << "number of nodes: " << _nodes.size() << std::flush;
 
   bool checkifoutput = (_outputtime != 0);
   double nexttrajoutput = 0;
@@ -211,38 +211,39 @@ void KMCMultiple::RunVSSM() {
 
   if (_runtime > 100) {
     XTP_LOG(Log::error, _log)
-        << "stop condition: " << maxsteps << " steps." << flush;
+        << "stop condition: " << maxsteps << " steps." << std::flush;
 
     if (checkifoutput) {
       XTP_LOG(Log::error, _log) << "output frequency: ";
-      XTP_LOG(Log::error, _log) << "every " << outputstep << " steps." << flush;
+      XTP_LOG(Log::error, _log)
+          << "every " << outputstep << " steps." << std::flush;
     }
   } else {
     stopontime = true;
     XTP_LOG(Log::error, _log)
-        << "stop condition: " << _runtime << " seconds runtime." << flush;
+        << "stop condition: " << _runtime << " seconds runtime." << std::flush;
 
     if (checkifoutput) {
       XTP_LOG(Log::error, _log) << "output frequency:\n "
                                    "every "
-                                << _outputtime << " seconds." << flush;
+                                << _outputtime << " seconds." << std::flush;
     }
   }
   XTP_LOG(Log::error, _log)
       << "(If you specify runtimes larger than 100 kmcmultiple assumes that "
          "you are specifying the number of steps for both runtime and "
          "outputtime.)"
-      << flush;
+      << std::flush;
 
   if (!stopontime && _outputtime != 0 && floor(_outputtime) != _outputtime) {
-    throw runtime_error(
+    throw std::runtime_error(
         "ERROR in kmcmultiple: runtime was specified in steps (>100) and "
         "outputtime in seconds (not an integer). Please use the same units for "
         "both input parameters.");
   }
 
   if (_numberofcarriers > Index(_nodes.size())) {
-    throw runtime_error(
+    throw std::runtime_error(
         "ERROR in kmcmultiple: specified number of carriers is greater than "
         "the "
         "number of nodes. This conflicts with single occupation.");
@@ -254,7 +255,7 @@ void KMCMultiple::RunVSSM() {
   if (checkifoutput) {
 
     XTP_LOG(Log::error, _log)
-        << "Writing trajectory to " << _trajectoryfile << "." << flush;
+        << "Writing trajectory to " << _trajectoryfile << "." << std::flush;
     traj.open(_trajectoryfile, std::fstream::out);
 
     traj << "time[s]\tsteps\t";
@@ -266,21 +267,21 @@ void KMCMultiple::RunVSSM() {
         traj << "'\t";
       }
     }
-    traj << endl;
+    traj << std::endl;
     if (!_timefile.empty()) {
       XTP_LOG(Log::error, _log)
           << "Writing time dependence of energy and mobility to " << _timefile
-          << "." << flush;
+          << "." << std::flush;
       tfile.open(_timefile, std::fstream::out);
       tfile << "time[s]\t "
                "steps\tenergy_per_carrier[eV]\tmobility[nm**2/"
                "Vs]\tdistance_fielddirection[nm]\tdistance_absolute[nm]"
-            << endl;
+            << std::endl;
     }
   }
   RandomlyCreateCharges();
-  vector<Eigen::Vector3d> startposition(_numberofcarriers,
-                                        Eigen::Vector3d::Zero());
+  std::vector<Eigen::Vector3d> startposition(_numberofcarriers,
+                                             Eigen::Vector3d::Zero());
   for (Index i = 0; i < _numberofcarriers; i++) {
     startposition[i] = _carriers[i].getCurrentPosition();
   }
@@ -294,12 +295,12 @@ void KMCMultiple::RunVSSM() {
     if (i < _numberofcarriers - 1) {
       traj << "\t";
     } else {
-      traj << endl;
+      traj << std::endl;
     }
   }
 
-  vector<GNode*> forbiddennodes;
-  vector<GNode*> forbiddendests;
+  std::vector<GNode*> forbiddennodes;
+  std::vector<GNode*> forbiddendests;
 
   Eigen::Matrix3d avgdiffusiontensor = Eigen::Matrix3d::Zero();
 
@@ -314,7 +315,7 @@ void KMCMultiple::RunVSSM() {
           << "\nReal time limit of " << _maxrealtime << " hours ("
           << Index(_maxrealtime * 60 * 60 + 0.5)
           << " seconds) has been reached. Stopping here.\n"
-          << flush;
+          << std::flush;
       break;
     }
 
@@ -324,7 +325,7 @@ void KMCMultiple::RunVSSM() {
     }
     if (cumulated_rate <= 0) {  // this should not happen: no possible jumps
                                 // defined for a node
-      throw runtime_error(
+      throw std::runtime_error(
           "ERROR in kmcmultiple: Incorrect rates. All "
           "the escape rates for the current setting are 0.");
     }
@@ -429,16 +430,16 @@ void KMCMultiple::RunVSSM() {
                             << " steps.\n"
                                "simulated time "
                             << simtime << " seconds.\n"
-                            << flush;
+                            << std::flush;
 
   PrintChargeVelocity(simtime);
 
-  XTP_LOG(Log::error, _log) << "\nDistances travelled (nm): " << flush;
+  XTP_LOG(Log::error, _log) << "\nDistances travelled (nm): " << std::flush;
   for (Index i = 0; i < _numberofcarriers; i++) {
     XTP_LOG(Log::error, _log)
         << std::scientific << "    carrier " << i + 1 << ": "
         << _carriers[i].get_dRtravelled().transpose() * tools::conv::bohr2nm
-        << flush;
+        << std::flush;
   }
 
   PrintDiffandMu(avgdiffusiontensor, simtime, step);
@@ -453,7 +454,8 @@ bool KMCMultiple::EvaluateFrame(Topology& top) {
                                "\n-----------------------------------\n"
                             << std::flush;
 
-  XTP_LOG(Log::info, _log) << "\nInitialising random number generator" << flush;
+  XTP_LOG(Log::info, _log) << "\nInitialising random number generator"
+                           << std::flush;
   _RandomVariable.init(_seed);
 
   LoadGraph(top);

--- a/src/libxtp/calculators/kmcmultiple.cc
+++ b/src/libxtp/calculators/kmcmultiple.cc
@@ -28,8 +28,6 @@ namespace votca {
 namespace xtp {
 void KMCMultiple::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/kmcmultiple.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _runtime = _options.ifExistsReturnElseThrowRuntimeError<double>(".runtime");

--- a/src/libxtp/calculators/kmcmultiple.cc
+++ b/src/libxtp/calculators/kmcmultiple.cc
@@ -26,25 +26,26 @@
 
 namespace votca {
 namespace xtp {
-void KMCMultiple::Initialize(tools::Property& options) {
-  std::string key = "options." + Identify();
-  ParseCommonOptions(options);
-  _runtime =
-      options.ifExistsReturnElseThrowRuntimeError<double>(key + ".runtime");
-  _field = options.ifExistsReturnElseReturnDefault<Eigen::Vector3d>(
-      key + ".field", Eigen::Vector3d::Zero());
+void KMCMultiple::Initialize(tools::Property& user_options) {
+
+  // get pre-defined default options from VOTCASHARE/xtp/xml/kmcmultiple.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
+
+  _runtime = _options.ifExistsReturnElseThrowRuntimeError<double>(".runtime");
+  _field =
+      _options.ifExistsReturnElseThrowRuntimeError<Eigen::Vector3d>(".field");
   double mtobohr = 1E9 * tools::conv::nm2bohr;
   _field *=
       (tools::conv::ev2hrt / mtobohr);  // Converting from V/m to Hartree/bohr
 
   _outputtime =
-      options.ifExistsReturnElseReturnDefault<double>(key + ".outputtime", 0);
-  _timefile = options.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".timefile", _timefile);
+      _options.ifExistsReturnElseThrowRuntimeError<double>(".outputtime");
+  _timefile = _options.ifExistsReturnElseReturnDefault<std::string>(".timefile",
+                                                                    _timefile);
 
   std::string carriertype =
-      options.ifExistsReturnElseReturnDefault<std::string>(key + ".carriertype",
-                                                           "e");
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".carriertype");
   _carriertype = QMStateType(carriertype);
   if (!_carriertype.isKMCState()) {
     throw std::runtime_error("KMC cannot be run for state:" +
@@ -53,7 +54,6 @@ void KMCMultiple::Initialize(tools::Property& options) {
 
   _log.setReportLevel(Log::current_level);
   _log.setCommonPreface("\n ...");
-  return;
 }
 
 void KMCMultiple::PrintDiffandMu(const Eigen::Matrix3d& avgdiffusiontensor,

--- a/src/libxtp/calculators/kmcmultiple.h
+++ b/src/libxtp/calculators/kmcmultiple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/libxtp/calculators/mapchecker.h
+++ b/src/libxtp/calculators/mapchecker.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -55,27 +55,31 @@ class MapChecker : public QMCalculator {
   std::vector<QMState> _mdstates;
 };
 
-void MapChecker::Initialize(tools::Property& opt) {
-  std::string key = "options." + Identify();
-  _segmentfile = opt.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".md_pdbfile", "md_segments.pdb");
+void MapChecker::Initialize(tools::Property& user_options) {
 
-  _qmfile = opt.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".qm_pdbfile", "qm_segments.pdb");
+  // get pre-defined default options from VOTCASHARE/xtp/xml/kmcmultiple.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
-  _mpfile = opt.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".mp_pdbfile", "mp_segments.pdb");
+  _segmentfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".md_pdbfile");
+
+  _qmfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".qm_pdbfile");
+
+  _mpfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".mp_pdbfile");
 
   std::string output_qm =
-      opt.ifExistsReturnElseReturnDefault<std::string>(key + ".qm_states", "");
+      _options.ifExistsReturnElseReturnDefault<std::string>(".qm_states", "");
 
   _qmstates = StringToStates(output_qm);
   std::string output_md =
-      opt.ifExistsReturnElseReturnDefault<std::string>(key + ".mp_states", "");
+      _options.ifExistsReturnElseReturnDefault<std::string>(".mp_states", "");
   _mdstates = StringToStates(output_md);
   if (!(_qmstates.empty() && _mdstates.empty())) {
     _mapfile =
-        opt.ifExistsReturnElseThrowRuntimeError<std::string>(key + ".map_file");
+        _options.ifExistsReturnElseThrowRuntimeError<std::string>(".map_file");
   }
 }
 

--- a/src/libxtp/calculators/mapchecker.h
+++ b/src/libxtp/calculators/mapchecker.h
@@ -57,8 +57,6 @@ class MapChecker : public QMCalculator {
 
 void MapChecker::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/kmcmultiple.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _segmentfile =

--- a/src/libxtp/calculators/neighborlist.cc
+++ b/src/libxtp/calculators/neighborlist.cc
@@ -24,8 +24,6 @@ namespace xtp {
 
 void Neighborlist::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/neighborlist.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   std::vector<tools::Property*> segs = _options.Select(".segments");

--- a/src/libxtp/calculators/neighborlist.cc
+++ b/src/libxtp/calculators/neighborlist.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,17 @@
 #include "neighborlist.h"
 #include <boost/format.hpp>
 #include <boost/progress.hpp>
-using namespace std;
 
 namespace votca {
 namespace xtp {
 
-void Neighborlist::Initialize(tools::Property& options) {
+void Neighborlist::Initialize(tools::Property& user_options) {
 
-  // update options with the VOTCASHARE defaults
-  UpdateWithDefaults(options, "xtp");
-  std::string key = "options." + Identify();
+  // get pre-defined default options from VOTCASHARE/xtp/xml/neighborlist.xml
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
-  std::vector<tools::Property*> segs = options.Select(key + ".segments");
+  std::vector<tools::Property*> segs = _options.Select(".segments");
 
   for (tools::Property* segprop : segs) {
     std::string types = segprop->get("type").as<std::string>();
@@ -56,17 +55,17 @@ void Neighborlist::Initialize(tools::Property& options) {
     }
   }
 
-  if (options.exists(key + ".constant")) {
+  if (_options.exists(".constant")) {
     _useConstantCutoff = true;
     _constantCutoff =
-        options.get(key + ".constant").as<double>() * tools::conv::nm2bohr;
+        _options.get(".constant").as<double>() * tools::conv::nm2bohr;
   } else {
     _useConstantCutoff = false;
   }
-  if (options.exists(key + ".exciton_cutoff")) {
+  if (_options.exists(".exciton_cutoff")) {
     _useExcitonCutoff = true;
-    _excitonqmCutoff = options.get(key + ".exciton_cutoff").as<double>() *
-                       tools::conv::nm2bohr;
+    _excitonqmCutoff =
+        _options.get(".exciton_cutoff").as<double>() * tools::conv::nm2bohr;
   } else {
     _useExcitonCutoff = false;
   }

--- a/src/libxtp/calculators/neighborlist.h
+++ b/src/libxtp/calculators/neighborlist.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/libxtp/calculators/vaverage.cc
+++ b/src/libxtp/calculators/vaverage.cc
@@ -25,8 +25,6 @@ namespace xtp {
 
 void VAverage::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/vaverage.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _ratefile =

--- a/src/libxtp/calculators/vaverage.cc
+++ b/src/libxtp/calculators/vaverage.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -23,14 +23,18 @@
 namespace votca {
 namespace xtp {
 
-void VAverage::Initialize(tools::Property& options) {
-  std::string key = "options." + Identify();
-  _ratefile = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".ratefile");
-  _occfile = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".occfile");
-  _outputfile = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".outputfile");
+void VAverage::Initialize(tools::Property& user_options) {
+
+  // get pre-defined default options from VOTCASHARE/xtp/xml/vaverage.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
+
+  _ratefile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".ratefile");
+  _occfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".occfile");
+  _outputfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".outputfile");
 }
 
 std::vector<double> VAverage::ReadOccfile(std::string filename) const {

--- a/src/libxtp/tools/apdft.cc
+++ b/src/libxtp/tools/apdft.cc
@@ -25,10 +25,9 @@ namespace xtp {
 
 void APDFT::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/apdft.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // get pre-defined default options from VOTCASHARE/xtp/xml/apdft.xml and merge
+  // it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _grid_accuracy =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".grid");

--- a/src/libxtp/tools/apdft.cc
+++ b/src/libxtp/tools/apdft.cc
@@ -25,8 +25,6 @@ namespace xtp {
 
 void APDFT::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/apdft.xml and merge
-  // it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _grid_accuracy =

--- a/src/libxtp/tools/coupling.h
+++ b/src/libxtp/tools/coupling.h
@@ -53,10 +53,9 @@ class Coupling : public QMTool {
 
 void Coupling::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/coupling.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // get pre-defined default options from VOTCASHARE/xtp/xml/coupling.xml and
+  // merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _MOsA = _options.get(".moleculeA.orbitals").as<std::string>();
   _MOsB = _options.get(".moleculeB.orbitals").as<std::string>();

--- a/src/libxtp/tools/coupling.h
+++ b/src/libxtp/tools/coupling.h
@@ -53,8 +53,6 @@ class Coupling : public QMTool {
 
 void Coupling::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/coupling.xml and
-  // merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _MOsA = _options.get(".moleculeA.orbitals").as<std::string>();

--- a/src/libxtp/tools/densityanalysis.h
+++ b/src/libxtp/tools/densityanalysis.h
@@ -46,8 +46,6 @@ class DensityAnalysis : public QMTool {
 
 void DensityAnalysis::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/densityanalysis.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _gyration_options.get(".density2gyration");

--- a/src/libxtp/tools/densityanalysis.h
+++ b/src/libxtp/tools/densityanalysis.h
@@ -47,9 +47,8 @@ class DensityAnalysis : public QMTool {
 void DensityAnalysis::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/densityanalysis.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _gyration_options.get(".density2gyration");
 }

--- a/src/libxtp/tools/dftgwbse.cc
+++ b/src/libxtp/tools/dftgwbse.cc
@@ -24,8 +24,6 @@
 #include <votca/xtp/segment.h>
 #include <votca/xtp/staticregion.h>
 
-using namespace std;
-
 namespace votca {
 namespace xtp {
 
@@ -37,35 +35,35 @@ void DftGwBse::Initialize(tools::Property& user_options) {
   UpdateWithUserOptions(user_options);
 
   // molecule coordinates
-  _xyzfile = _options.ifExistsReturnElseThrowRuntimeError<string>(".molecule");
+  _xyzfile = _options.ifExistsReturnElseThrowRuntimeError<std::string>(".molecule");
 
   // job tasks
-  std::vector<string> choices = {"optimize", "energy"};
-  string mode = _options.ifExistsAndinListReturnElseThrowRuntimeError<string>(
+  std::vector<std::string> choices = {"optimize", "energy"};
+  std::string mode = _options.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
       ".mode", choices);
 
   // options for dft package
   _package_options = _options.get(".dftpackage");
-  _package = _package_options.get("package.name").as<string>();
+  _package = _package_options.get("package.name").as<std::string>();
 
   // set the basis sets and functional in DFT package
   _package_options.get("package").add("basisset",
-                                      _options.get("basisset").as<string>());
+                                      _options.get("basisset").as<std::string>());
   _package_options.get("package").add("auxbasisset",
-                                      _options.get("auxbasisset").as<string>());
+                                      _options.get("auxbasisset").as<std::string>());
   _package_options.get("package").add("functional",
-                                      _options.get("functional").as<string>());
+                                      _options.get("functional").as<std::string>());
 
   // GWBSEENGINE options
   _gwbseengine_options = _options.get(".gwbse_engine");
 
   // set the basis sets and functional in GWBSE
   _gwbseengine_options.get("gwbse_options.gwbse")
-      .add("basisset", _options.get("basisset").as<string>());
+      .add("basisset", _options.get("basisset").as<std::string>());
   _gwbseengine_options.get("gwbse_options.gwbse")
-      .add("auxbasisset", _options.get("auxbasisset").as<string>());
+      .add("auxbasisset", _options.get("auxbasisset").as<std::string>());
   _gwbseengine_options.get("gwbse_options.gwbse.vxc")
-      .add("functional", _options.get("functional").as<string>());
+      .add("functional", _options.get("functional").as<std::string>());
 
   // lets get the archive file name from the xyz file name
   _archive_file = tools::filesystem::GetFileBase(_xyzfile) + ".orb";
@@ -81,13 +79,13 @@ void DftGwBse::Initialize(tools::Property& user_options) {
   // check for MPS file with external multipoles for embedding
   if (_options.exists(".mpsfile")) {
     _do_external = true;
-    _mpsfile = _options.get(".mpsfile").as<string>();
+    _mpsfile = _options.get(".mpsfile").as<std::string>();
   }
 
   // check if guess is requested
   if (_options.exists(".guess")) {
     _do_guess = true;
-    _guess_file = _options.get(".guess").as<string>();
+    _guess_file = _options.get(".guess").as<std::string>();
   }
 
   // if optimization is chosen, get options for geometry_optimizer
@@ -112,10 +110,10 @@ bool DftGwBse::Evaluate() {
   Orbitals orbitals;
 
   if (_do_guess) {
-    XTP_LOG(Log::error, _log) << "Reading guess from " << _guess_file << flush;
+    XTP_LOG(Log::error, _log) << "Reading guess from " << _guess_file << std::flush;
     orbitals.ReadFromCpt(_guess_file);
   } else {
-    XTP_LOG(Log::error, _log) << "Reading structure from " << _xyzfile << flush;
+    XTP_LOG(Log::error, _log) << "Reading structure from " << _xyzfile << std::flush;
     orbitals.QMAtoms().LoadFromFile(_xyzfile);
   }
 
@@ -147,7 +145,7 @@ bool DftGwBse::Evaluate() {
     gwbse_engine.ExcitationEnergies(orbitals);
   }
 
-  XTP_LOG(Log::error, _log) << "Saving data to " << _archive_file << flush;
+  XTP_LOG(Log::error, _log) << "Saving data to " << _archive_file << std::flush;
   orbitals.WriteToCpt(_archive_file);
 
   tools::Property summary = gwbse_engine.ReportSummary();
@@ -155,7 +153,7 @@ bool DftGwBse::Evaluate() {
                                    // actually did gwbse
     tools::PropertyIOManipulator iomXML(tools::PropertyIOManipulator::XML, 1,
                                         "");
-    XTP_LOG(Log::error, _log) << "Writing output to " << _xml_output << flush;
+    XTP_LOG(Log::error, _log) << "Writing output to " << _xml_output << std::flush;
     std::ofstream ofout(_xml_output, std::ofstream::out);
     ofout << (summary.get("output"));
     ofout.close();

--- a/src/libxtp/tools/dftgwbse.cc
+++ b/src/libxtp/tools/dftgwbse.cc
@@ -29,8 +29,6 @@ namespace xtp {
 
 void DftGwBse::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/dftgwbse.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   // molecule coordinates

--- a/src/libxtp/tools/dftgwbse.cc
+++ b/src/libxtp/tools/dftgwbse.cc
@@ -30,29 +30,30 @@ namespace xtp {
 void DftGwBse::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/dftgwbse.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   // molecule coordinates
-  _xyzfile = _options.ifExistsReturnElseThrowRuntimeError<std::string>(".molecule");
+  _xyzfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".molecule");
 
   // job tasks
   std::vector<std::string> choices = {"optimize", "energy"};
-  std::string mode = _options.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
-      ".mode", choices);
+  std::string mode =
+      _options.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
+          ".mode", choices);
 
   // options for dft package
   _package_options = _options.get(".dftpackage");
   _package = _package_options.get("package.name").as<std::string>();
 
   // set the basis sets and functional in DFT package
-  _package_options.get("package").add("basisset",
-                                      _options.get("basisset").as<std::string>());
-  _package_options.get("package").add("auxbasisset",
-                                      _options.get("auxbasisset").as<std::string>());
-  _package_options.get("package").add("functional",
-                                      _options.get("functional").as<std::string>());
+  _package_options.get("package").add(
+      "basisset", _options.get("basisset").as<std::string>());
+  _package_options.get("package").add(
+      "auxbasisset", _options.get("auxbasisset").as<std::string>());
+  _package_options.get("package").add(
+      "functional", _options.get("functional").as<std::string>());
 
   // GWBSEENGINE options
   _gwbseengine_options = _options.get(".gwbse_engine");
@@ -110,10 +111,12 @@ bool DftGwBse::Evaluate() {
   Orbitals orbitals;
 
   if (_do_guess) {
-    XTP_LOG(Log::error, _log) << "Reading guess from " << _guess_file << std::flush;
+    XTP_LOG(Log::error, _log)
+        << "Reading guess from " << _guess_file << std::flush;
     orbitals.ReadFromCpt(_guess_file);
   } else {
-    XTP_LOG(Log::error, _log) << "Reading structure from " << _xyzfile << std::flush;
+    XTP_LOG(Log::error, _log)
+        << "Reading structure from " << _xyzfile << std::flush;
     orbitals.QMAtoms().LoadFromFile(_xyzfile);
   }
 
@@ -153,7 +156,8 @@ bool DftGwBse::Evaluate() {
                                    // actually did gwbse
     tools::PropertyIOManipulator iomXML(tools::PropertyIOManipulator::XML, 1,
                                         "");
-    XTP_LOG(Log::error, _log) << "Writing output to " << _xml_output << std::flush;
+    XTP_LOG(Log::error, _log)
+        << "Writing output to " << _xml_output << std::flush;
     std::ofstream ofout(_xml_output, std::ofstream::out);
     ofout << (summary.get("output"));
     ofout.close();

--- a/src/libxtp/tools/excitoncoupling.h
+++ b/src/libxtp/tools/excitoncoupling.h
@@ -55,9 +55,8 @@ class ExcitonCoupling : public QMTool {
 void ExcitonCoupling::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/excitoncoupling.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _classical = _options.get(".classical").as<bool>();
 

--- a/src/libxtp/tools/excitoncoupling.h
+++ b/src/libxtp/tools/excitoncoupling.h
@@ -54,8 +54,6 @@ class ExcitonCoupling : public QMTool {
 
 void ExcitonCoupling::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/excitoncoupling.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _classical = _options.get(".classical").as<bool>();

--- a/src/libxtp/tools/gencube.cc
+++ b/src/libxtp/tools/gencube.cc
@@ -32,9 +32,8 @@ namespace xtp {
 void GenCube::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/gencube.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".input");

--- a/src/libxtp/tools/gencube.cc
+++ b/src/libxtp/tools/gencube.cc
@@ -31,8 +31,6 @@ namespace xtp {
 
 void GenCube::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/gencube.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =

--- a/src/libxtp/tools/gencube.cc
+++ b/src/libxtp/tools/gencube.cc
@@ -29,8 +29,6 @@
 namespace votca {
 namespace xtp {
 
-using namespace std;
-
 void GenCube::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/gencube.xml
@@ -67,29 +65,31 @@ void GenCube::Initialize(tools::Property& user_options) {
 void GenCube::calculateCube() {
 
   XTP_LOG(Log::error, _log)
-      << "Reading serialized QM data from " << _orbfile << flush;
+      << "Reading serialized QM data from " << _orbfile << std::flush;
 
   Orbitals orbitals;
   orbitals.ReadFromCpt(_orbfile);
 
   CubeFile_Writer writer(_steps, _padding, _log);
-  XTP_LOG(Log::error, _log) << "Created cube grid" << flush;
+  XTP_LOG(Log::error, _log) << "Created cube grid" << std::flush;
   writer.WriteFile(_output_file, orbitals, _state, _dostateonly);
-  XTP_LOG(Log::error, _log) << "Wrote cube data to " << _output_file << flush;
+  XTP_LOG(Log::error, _log)
+      << "Wrote cube data to " << _output_file << std::flush;
   return;
 }
 
 void GenCube::subtractCubes() {
 
   // open infiles for reading
-  ifstream in1;
-  XTP_LOG(Log::error, _log) << " Reading first cube from " << _infile1 << flush;
-  in1.open(_infile1, ios::in);
-  ifstream in2;
+  std::ifstream in1;
   XTP_LOG(Log::error, _log)
-      << " Reading second cube from " << _infile2 << flush;
-  in2.open(_infile2, ios::in);
-  string s;
+      << " Reading first cube from " << _infile1 << std::flush;
+  in1.open(_infile1, std::ios::in);
+  std::ifstream in2;
+  XTP_LOG(Log::error, _log)
+      << " Reading second cube from " << _infile2 << std::flush;
+  in2.open(_infile2, std::ios::in);
+  std::string s;
 
   std::ofstream out(_output_file);
 
@@ -274,7 +274,7 @@ void GenCube::subtractCubes() {
 
   out.close();
   XTP_LOG(Log::error, _log)
-      << "Wrote subtracted cube data to " << _output_file << flush;
+      << "Wrote subtracted cube data to " << _output_file << std::flush;
 }
 
 bool GenCube::Evaluate() {

--- a/src/libxtp/tools/log2mps.h
+++ b/src/libxtp/tools/log2mps.h
@@ -47,8 +47,6 @@ class Log2Mps : public QMTool {
 
 void Log2Mps::Initialize(tools::Property &user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/log2mps.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   QMPackageFactory::RegisterAll();

--- a/src/libxtp/tools/log2mps.h
+++ b/src/libxtp/tools/log2mps.h
@@ -48,9 +48,8 @@ class Log2Mps : public QMTool {
 void Log2Mps::Initialize(tools::Property &user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/log2mps.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   QMPackageFactory::RegisterAll();
 

--- a/src/libxtp/tools/molpol.cc
+++ b/src/libxtp/tools/molpol.cc
@@ -28,9 +28,8 @@ namespace xtp {
 void MolPol::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/molpol.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   std::string mps_input =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".mpsinput");
@@ -104,7 +103,8 @@ void MolPol::Initialize(tools::Property& user_options) {
   _tolerance_pol =
       _options.ifExistsReturnElseThrowRuntimeError<double>(".tolerance");
 
-  _max_iter = _options.ifExistsReturnElseThrowRuntimeError<Index>(".iterations");
+  _max_iter =
+      _options.ifExistsReturnElseThrowRuntimeError<Index>(".iterations");
 }
 
 Eigen::Vector3d MolPol::CalcInducedDipole(

--- a/src/libxtp/tools/molpol.cc
+++ b/src/libxtp/tools/molpol.cc
@@ -27,8 +27,6 @@ namespace xtp {
 
 void MolPol::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/molpol.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   std::string mps_input =

--- a/src/libxtp/tools/partialcharges.h
+++ b/src/libxtp/tools/partialcharges.h
@@ -50,9 +50,8 @@ class Partialcharges : public QMTool {
 void Partialcharges::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/partialcharges.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".input");

--- a/src/libxtp/tools/partialcharges.h
+++ b/src/libxtp/tools/partialcharges.h
@@ -49,8 +49,6 @@ class Partialcharges : public QMTool {
 
 void Partialcharges::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/partialcharges.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =

--- a/src/libxtp/tools/qmsandbox.h
+++ b/src/libxtp/tools/qmsandbox.h
@@ -53,9 +53,8 @@ class QMSandbox : public QMTool {
 void QMSandbox::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/qmsandbox.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =
       _options.ifExistsReturnElseThrowRuntimeError<std::string>(".orbfile");

--- a/src/libxtp/tools/qmsandbox.h
+++ b/src/libxtp/tools/qmsandbox.h
@@ -52,8 +52,6 @@ class QMSandbox : public QMTool {
 
 void QMSandbox::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/qmsandbox.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   _orbfile =

--- a/src/libxtp/tools/spectrum.cc
+++ b/src/libxtp/tools/spectrum.cc
@@ -27,8 +27,6 @@ namespace xtp {
 
 void Spectrum::Initialize(tools::Property& user_options) {
 
-  // get pre-defined default options from VOTCASHARE/xtp/xml/spectrum.xml
-  // and merge it with the user input
   LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   // orbitals file or pure DFT output

--- a/src/libxtp/tools/spectrum.cc
+++ b/src/libxtp/tools/spectrum.cc
@@ -28,9 +28,8 @@ namespace xtp {
 void Spectrum::Initialize(tools::Property& user_options) {
 
   // get pre-defined default options from VOTCASHARE/xtp/xml/spectrum.xml
-  LoadDefaults("xtp");
-  // update options with user specified input
-  UpdateWithUserOptions(user_options);
+  // and merge it with the user input
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
 
   // orbitals file or pure DFT output
   _orbfile =

--- a/src/tools/xtp_run.cc
+++ b/src/tools/xtp_run.cc
@@ -103,7 +103,6 @@ bool XtpRun::EvaluateOptions() {
   for (const auto& calc : xtp::Calculators().getObjects()) {
 
     if (calc_string[0].compare(calc.first) == 0) {
-      std::cout << " This is a XTP app\n";
       xtp::StateApplication::SetCalculator(
           xtp::Calculators().Create(calc_string[0]));
       found_calc = true;

--- a/src/tools/xtp_run.cc
+++ b/src/tools/xtp_run.cc
@@ -17,21 +17,18 @@
  *
  */
 
-#include <iostream>
-#include <stdlib.h>
 #include <string>
 #include <votca/xtp/calculatorfactory.h>
 #include <votca/xtp/stateapplication.h>
 
-using namespace std;
 using namespace votca;
 
 class XtpRun : public xtp::StateApplication {
  public:
-  string ProgramName() override { return "xtp_run"; }
+  std::string ProgramName() override { return "xtp_run"; }
 
-  void HelpText(ostream& out) override {
-    out << "Runs excitation/charge transport calculators" << endl;
+  void HelpText(std::ostream& out) override {
+    out << "Runs excitation/charge transport calculators\n";
   }
 
   void HelpText(){};
@@ -49,18 +46,18 @@ void XtpRun::Initialize() {
   xtp::Calculatorfactory::RegisterAll();
   xtp::StateApplication::Initialize();
 
-  AddProgramOptions("Calculator")("execute,e", propt::value<string>(),
+  AddProgramOptions("Calculator")("execute,e", propt::value<std::string>(),
                                   "Name of calculator to run");
   AddProgramOptions("Calculator")("list,l", "Lists all available calculators");
-  AddProgramOptions("Calculator")("description,d", propt::value<string>(),
+  AddProgramOptions("Calculator")("description,d", propt::value<std::string>(),
                                   "Short description of a calculator");
 }
 
 bool XtpRun::EvaluateOptions() {
 
-  string helpdir = "xtp/xml";
+  std::string helpdir = "xtp/xml";
   if (OptionsMap().count("list")) {
-    cout << "Available XTP calculators: \n";
+    std::cout << "Available XTP calculators:\n";
     for (const auto& calc : xtp::Calculators().getObjects()) {
       PrintDescription(std::cout, calc.first, helpdir, Application::HelpShort);
     }
@@ -70,7 +67,8 @@ bool XtpRun::EvaluateOptions() {
 
   if (OptionsMap().count("description")) {
     CheckRequired("description", "no calculator is given");
-    tools::Tokenizer tok(OptionsMap()["description"].as<string>(), " ,\n\t");
+    tools::Tokenizer tok(OptionsMap()["description"].as<std::string>(),
+                         " ,\n\t");
     // loop over the names in the description string
     for (const std::string& n : tok) {
       // loop over calculators
@@ -85,7 +83,7 @@ bool XtpRun::EvaluateOptions() {
         }
       }
       if (printerror) {
-        cout << "Calculator " << n << " does not exist\n";
+        std::cout << "Calculator " << n << " does not exist\n";
       }
     }
     StopExecution();
@@ -93,11 +91,9 @@ bool XtpRun::EvaluateOptions() {
   }
 
   xtp::StateApplication::EvaluateOptions();
-  CheckRequired("options",
-                "Please provide an xml file with calculator options");
   CheckRequired("execute", "Nothing to do here: Abort.");
 
-  tools::Tokenizer calcs(OptionsMap()["execute"].as<string>(), " ,\n\t");
+  tools::Tokenizer calcs(OptionsMap()["execute"].as<std::string>(), " ,\n\t");
   std::vector<std::string> calc_string = calcs.ToVector();
   if (calc_string.size() != 1) {
     throw std::runtime_error(
@@ -107,7 +103,7 @@ bool XtpRun::EvaluateOptions() {
   for (const auto& calc : xtp::Calculators().getObjects()) {
 
     if (calc_string[0].compare(calc.first) == 0) {
-      cout << " This is a XTP app" << endl;
+      std::cout << " This is a XTP app\n";
       xtp::StateApplication::SetCalculator(
           xtp::Calculators().Create(calc_string[0]));
       found_calc = true;
@@ -115,10 +111,10 @@ bool XtpRun::EvaluateOptions() {
     }
   }
   if (!found_calc) {
-    cout << "Calculator " << calc_string[0] << " does not exist\n";
+    std::cout << "Calculator " << calc_string[0] << " does not exist\n";
     StopExecution();
   } else {
-    _options.LoadFromXML(_op_vm["options"].as<string>());
+    _options.LoadFromXML(_op_vm["options"].as<std::string>());
   }
   return true;
 }

--- a/src/tools/xtp_tools.cc
+++ b/src/tools/xtp_tools.cc
@@ -27,7 +27,6 @@
 #include <votca/xtp/version.h>
 #include <votca/xtp/xtpapplication.h>
 
-using namespace std;
 using namespace votca;
 
 class XtpTools : public xtp::XtpApplication {
@@ -36,10 +35,10 @@ class XtpTools : public xtp::XtpApplication {
 
   ~XtpTools() override = default;
 
-  string ProgramName() override { return "xtp_tools"; }
+  std::string ProgramName() override { return "xtp_tools"; }
 
-  void HelpText(ostream& out) override {
-    out << "Runs excitation/charge transport tools" << endl;
+  void HelpText(std::ostream& out) override {
+    out << "Runs excitation/charge transport tools\n";
   }
 
   void SetTool(xtp::QMTool* tool) {
@@ -65,10 +64,10 @@ void XtpTools::Initialize() {
   xtp::XtpApplication::Initialize();
 
   // Tools-related
-  AddProgramOptions("Tools")("execute,e", propt::value<string>(),
+  AddProgramOptions("Tools")("execute,e", propt::value<std::string>(),
                              "List of tools separated by ',' or ' '");
   AddProgramOptions("Tools")("list,l", "Lists all available tools");
-  AddProgramOptions("Tools")("description,d", propt::value<string>(),
+  AddProgramOptions("Tools")("description,d", propt::value<std::string>(),
                              "Short description of a tool");
   // Options-related
   AddProgramOptions()("nthreads,t", propt::value<Index>()->default_value(1),
@@ -77,10 +76,10 @@ void XtpTools::Initialize() {
 
 bool XtpTools::EvaluateOptions() {
 
-  string helpdir = "xtp/xml";
+  std::string helpdir = "xtp/xml";
 
   if (OptionsMap().count("list")) {
-    cout << "Available XTP tools: \n";
+    std::cout << "Available XTP tools: \n";
 
     for (const auto& tool : xtp::QMTools().getObjects()) {
       PrintDescription(std::cout, tool.first, helpdir, Application::HelpShort);
@@ -91,7 +90,7 @@ bool XtpTools::EvaluateOptions() {
 
   if (OptionsMap().count("description")) {
     CheckRequired("description", "no tool is given");
-    tools::Tokenizer tok(OptionsMap()["description"].as<string>(), " ,\n\t");
+    tools::Tokenizer tok(OptionsMap()["description"].as<std::string>(), " ,\n\t");
     // loop over the names in the description string
     for (const std::string& n : tok) {
       // loop over tools
@@ -105,7 +104,7 @@ bool XtpTools::EvaluateOptions() {
         }
       }
       if (printerror) {
-        cout << "Tool " << n << " does not exist\n";
+        std::cout << "Tool " << n << " does not exist\n";
       }
     }
     StopExecution();
@@ -114,7 +113,7 @@ bool XtpTools::EvaluateOptions() {
 
   CheckRequired("execute", "Please provide the name of the tool to execute");
 
-  tools::Tokenizer xtools(OptionsMap()["execute"].as<string>(), " ,\n\t");
+  tools::Tokenizer xtools(OptionsMap()["execute"].as<std::string>(), " ,\n\t");
   std::vector<std::string> calc_string = xtools.ToVector();
   if (calc_string.size() != 1) {
     throw std::runtime_error(
@@ -124,17 +123,17 @@ bool XtpTools::EvaluateOptions() {
   bool found_calc = false;
   for (const auto& tool : xtp::QMTools().getObjects()) {
     if (calc_string[0].compare(tool.first) == 0) {
-      cout << " This is a XTP app" << endl;
+      std::cout << " This is a XTP app\n";
       this->SetTool(xtp::QMTools().Create(calc_string[0]));
       found_calc = true;
       break;
     }
   }
   if (!found_calc) {
-    cout << "Tool " << calc_string[0] << " does not exist\n";
+    std::cout << "Tool " << calc_string[0] << " does not exist\n";
     StopExecution();
   } else {
-    cout << "Registered " << calc_string[0] << endl;
+    std::cout << "Registered " << calc_string[0];
   }
   return 1;
 }
@@ -143,7 +142,7 @@ void XtpTools::Run() {
 
   auto it = _op_vm.find("options");
   if (it != _op_vm.cend()) {
-    string optionsFile = _op_vm["options"].as<string>();
+    std::string optionsFile = _op_vm["options"].as<std::string>();
     _options.LoadFromXML(optionsFile);
   }
 
@@ -153,26 +152,24 @@ void XtpTools::Run() {
     name = name + ", version " + VersionString();
   }
   xtp::HelpTextHeader(name);
-  cout << "Initializing tool " << endl;
+  std::cout << "Initializing tool\n";
   BeginEvaluate(nThreads);
 
-  cout << "Evaluating tool " << endl;
+  std::cout << "Evaluating tool\n";
 
   Evaluate();
 }
 
 void XtpTools::BeginEvaluate(Index nThreads = 1) {
-  cout << "... " << _tool->Identify() << " " << flush;
+  std::cout << "... " << _tool->Identify() << " " << std::flush;
   _tool->setnThreads(nThreads);
   _tool->Initialize(_options);
-  cout << endl;
 }
 
 bool XtpTools::Evaluate() {
 
-  cout << "... " << _tool->Identify() << " " << flush;
+  std::cout << "... " << _tool->Identify() << " " << std::flush;
   _tool->Evaluate();
-  cout << endl;
   return true;
 }
 

--- a/src/tools/xtp_tools.cc
+++ b/src/tools/xtp_tools.cc
@@ -90,7 +90,8 @@ bool XtpTools::EvaluateOptions() {
 
   if (OptionsMap().count("description")) {
     CheckRequired("description", "no tool is given");
-    tools::Tokenizer tok(OptionsMap()["description"].as<std::string>(), " ,\n\t");
+    tools::Tokenizer tok(OptionsMap()["description"].as<std::string>(),
+                         " ,\n\t");
     // loop over the names in the description string
     for (const std::string& n : tok) {
       // loop over tools
@@ -123,7 +124,6 @@ bool XtpTools::EvaluateOptions() {
   bool found_calc = false;
   for (const auto& tool : xtp::QMTools().getObjects()) {
     if (calc_string[0].compare(tool.first) == 0) {
-      std::cout << " This is a XTP app\n";
       this->SetTool(xtp::QMTools().Create(calc_string[0]));
       found_calc = true;
       break;


### PR DESCRIPTION
See: #319 
## changed
The `options` file is now optional for the following `xtp_run` calculators:
   * [x] eanalyze
   * [x] einternal
   * [x] ianalyze
   * [x] kmclifetime
   * [x] kmcmultiple
   * [x] mapchecker
   * [x] neighborlist
   * [x] vaverage