### PR TITLE
allow options file to be optional for xtp_parallel

### DIFF
--- a/include/votca/xtp/parallelxjobcalc.h
+++ b/include/votca/xtp/parallelxjobcalc.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -88,7 +88,7 @@ class ParallelXJobCalc : public JobCalculator {
   };
 
  protected:
-  void ParseCommonOptions(const tools::Property &options);
+  void ParseCommonOptions();
 
   JobContainer _XJobs;
   tools::Mutex _coutMutex;

--- a/share/xtp/xml/eqm.xml
+++ b/share/xtp/xml/eqm.xml
@@ -2,13 +2,61 @@
 
 <eqm help="Executes qm calculations for individual molecules" section="sec:eqm">
 
-<tasks help="tasks to perform during calculation input,dft,parse,gwbse,esp">input,dft,parse,gwbse,esp</tasks>
+	<tasks help="tasks to perform during calculation input,dft,parse,gwbse,esp" default="input,dft,parse,gwbse,esp">input,dft,parse,gwbse,esp</tasks>
+	<job_file help="name of jobfile to which jobs are written" default="eqm.jobs">eqm.jobs</job_file>
+	<map_file help="xml file with segment definition" default="votca_map.xml">votca_map.xml</map_file>
 
-<job_file help="name of jobfile to which jobs are written">eqm.jobs</job_file>
-<map_file help="xml file with segment definition">system.xml</map_file>
-<gwbse_options help="xml file with options for gwbse calculations">OPTIONFILES/gwbse_egwbse_molecule.xml</gwbse_options>
-<dftpackage help="xml file with options for dft calculations">OPTIONFILES/gaussian_egwbse_molecule.xml</dftpackage>
-<esp_options help="xml file with options for CHELPG calculations">OPTIONFILES/esp2multipole.xml</esp_options>
+    <gwbse_options help="xml file with options for gwbse calculations">
+   	    <gwbse>
+		    <ranges help="default: all levels in RPA, 1:2*HOMO in QP and all in BSE; other options: factor,explicit">default</ranges>
+	        <rpamax help="only needed, if ranges is factor or explicit, number of levels in rpa" default=""></rpamax>
+	        <qpmin help="only needed, if ranges is factor or explicit, lowest MO to be used in GW" default="" ></qpmin>
+	        <qpmax help="only needed, if ranges is factor or explicit, highest MO to be used in GW" default=""></qpmax>
+	        <bsemin help="only needed, if ranges is factor or explicit, lowest MO to be used in BSE" default=""></bsemin>
+	        <bsemax help="only needed, if ranges is factor or explicit, highest MO to be used in BSE" default=""></bsemax>
+	        <vxc help="Exchange correlation functional computation for GW">
+	            <grid help="grid quality xcoarse,coarse,medium,fine,xfine" default="medium">medium</grid>
+	        </vxc>
+	        <scissor_shift help="preshift unoccupied MOs by a constant for GW calculation" default="0.0" unit="hartree">0.0</scissor_shift>
+	        <mode help="use single short (G0W0) or self-consistent GW (evGW)" default="evGW">evGW</mode>
+	        <tasks help="tasks to do gw,singlets,triplets or all" default="gw,singlets">gw,singlets</tasks>
+	        <sigma_integrator help="self-energy correlation integration method: ppm, exact" default="ppm">ppm</sigma_integrator>
+	        <eta help="small parameter eta of the Green's function" default="1e-3">1e-3</eta>
+	        <qp_solver help="QP equation solve method: fixedpoint, grid" default="grid">grid</qp_solver>
+	        <qp_grid_steps help="number of QP grid points" default="1001">1001</qp_grid_steps>
+	        <qp_grid_spacing help="spacing of QP grid points in Ha" default="0.001">0.001</qp_grid_spacing>
+	        <exctotal help="maximum number of BSE states to calculate" default="30">30</exctotal>
+	        <useTDA help="use TDA for BSE default `false`" default="0">0</useTDA>
+	        <ignore_corelevels help="exclude core MO level from calculation on RPA,GW or BSE level" default="no">no</ignore_corelevels>
+	        <eigensolver help="options for BSE eigenvalue decompostion">
+	            <dodavidson help="use davidson solver" default="1">1</dodavidson>
+	            <davidson_correction help="DPR or OHLSEN" default="DPR">DPR</davidson_correction>
+	            <davidson_tolerance help="loose,normal,strict" default="strict">strict</davidson_tolerance>
+	            <davidson_ortho help="orthogonalisation routine GS or QR" default="GS">GS</davidson_ortho>
+	            <davidson_update help=" how large the search space can become min, safe, max" default="safe">safe</davidson_update>
+	            <davidson_maxiter help="max iterations" default="50">50</davidson_maxiter>
+	            <domatrixfree help="solve without explicitly setting up BSE matrix, (slower but a lot less memory required" default="0">0</domatrixfree>
+	        </eigensolver>
+	        <gw_sc_max_iterations help="Maximum number of iterations in gvGW" default="50">50</gw_sc_max_iterations>
+	        <gw_mixing_order help="Mixing of QP energies in evGW - 0: plain, 1: linear, >1: Anderson" default="20">20</gw_mixing_order>
+	        <g_sc_max_iterations help="What is this again?" default="100">100</g_sc_max_iterations>
+	        <use_Hqp_offdiagonals help="Using symmetrized off-diagonal elements of QP Hamiltonian in BSE" default="false">false</use_Hqp_offdiagonals>
+        </gwbse>
+    </gwbse_options>
+
+	<dftpackage>
+    	<package>
+        	<name help="Name of the DFT package" default="xtp">xtp</name>
+    	</package>
+	</dftpackage>
+
+	<esp_options help="xml file with options for CHELPG calculations">
+    	<esp2multipole>
+        	<state help="ground-,excited or transitionstate (groundstate,singlet,n2s1)" default="n2S1">n2S1</state>
+        	<method help="Method to use derive partial charges, CHELPG and Mulliken implented" default="CHELPG">CHELPG</method>
+        	<gridsize help="Grid accuracy for numerical integration within CHELPG and GDMA coarse,medium,fine" default="fine">fine</gridsize>
+    	</esp2multipole>
+	</esp_options>
 </eqm>
 
 </options>

--- a/share/xtp/xml/iexcitoncl.xml
+++ b/share/xtp/xml/iexcitoncl.xml
@@ -1,7 +1,6 @@
 <options>
     <iexcitoncl help="Classical coupling of transition charges" section="sec:iexcitoncl">
-        <map_file help="xml file with segment definition">system.xml</map_file>
-        <job_file help="name of jobfile to which jobs are written">exciton.jobs</job_file>
-        <states help="which state for which type of molecule to use">Methane:n2s1</states>
+        <map_file help="xml file with segment definition" default="votca_map.xml">votca_map.xml</map_file>
+        <job_file help="name of jobfile to which jobs are written" default="exciton.jobs">exciton.jobs</job_file>
     </iexcitoncl>
 </options>

--- a/share/xtp/xml/iqm.xml
+++ b/share/xtp/xml/iqm.xml
@@ -1,28 +1,81 @@
 <options>
 
-    <iqm help="QM calculator for pairs" section="sec:iqm">
-        <job_file help="name of jobfile to which jobs are written">iqm.jobs</job_file>
-        <map_file help="xml file with segment definition">system.xml</map_file>
+<iqm help="QM calculator for pairs" section="sec:iqm">
+    <job_file help="name of jobfile to which jobs are written" default="iqm.jobs">iqm.jobs</job_file>
+    <map_file help="xml file with segment definition" default="votca_map.xml">votca_map.xml</map_file>
+    <tasks help="tasks to perform during calculation >input,dft,parse,dftcoupling,gwbse,bsecoupling" default="input,dft,parse,dftcoupling,gwbse,bsecoupling">input,dft,parse,dftcoupling,gwbse,bsecoupling</tasks>
+    <store help="store gw/dft results in hdf5 file, can require a lot of disk space in large systems"></store>
 
-        <tasks help="tasks to perform during calculation >input,dft,parse,dftcoupling,gwbse,bsecoupling">input,dft,parse,dftcoupling,gwbse,bsecoupling</tasks>
-        <store help="store gw/dft results in hdf5 file, can require a lot of disk space in large systems"></store>
-        <gwbse_options help="xml file with options for gwbse calculations"></gwbse_options>
-        <bsecoupling_options help="xml file with options for gwbse calculations">bsecoupling.xml</bsecoupling_options>
-        <dftcoupling_options>
-            <degeneracy help="Criterium for the degeneracy of two levels" unit="eV" default="0">0.0</degeneracy>
-            <levA help="Output HOMO, ..., HOMO-levels; LUMO, ..., LUMO+levels, molecule A">1</levA>
-            <levB help="Output HOMO, ..., HOMO-levels; LUMO, ..., LUMO+levels, molecule B">1</levB>
-        </dftcoupling_options>
-        <dftpackage help="xml file with options for dft calculations">gaussian_pair_bse.xml</dftpackage>
-        <readjobfile help="which states to read into the jobfile for each segment type">
-            <singlet>DCV5T:s1, C60:s2</singlet>
-            <triplet>DCV5T:t2, C60:t1</triplet>
-            <electron>DCV5T:e1, C60:e1</electron>
-            <hole>DCV5T:h1, C60:h1</hole>
-        </readjobfile>
-    </iqm>
+    <gwbse_options help="xml file with options for gwbse calculations">
+        <gwbse>
+		    <ranges help="default: all levels in RPA, 1:2*HOMO in QP and all in BSE; other options: factor,explicit">default</ranges>
+	        <rpamax help="only needed, if ranges is factor or explicit, number of levels in rpa" default=""></rpamax>
+	        <qpmin help="only needed, if ranges is factor or explicit, lowest MO to be used in GW" default="" ></qpmin>
+	        <qpmax help="only needed, if ranges is factor or explicit, highest MO to be used in GW" default=""></qpmax>
+	        <bsemin help="only needed, if ranges is factor or explicit, lowest MO to be used in BSE" default=""></bsemin>
+	        <bsemax help="only needed, if ranges is factor or explicit, highest MO to be used in BSE" default=""></bsemax>
+	        <vxc help="Exchange correlation functional computation for GW">
+	            <grid help="grid quality xcoarse,coarse,medium,fine,xfine" default="medium">medium</grid>
+	        </vxc>
+	        <scissor_shift help="preshift unoccupied MOs by a constant for GW calculation" default="0.0" unit="hartree">0.0</scissor_shift>
+	        <mode help="use single short (G0W0) or self-consistent GW (evGW)" default="evGW">evGW</mode>
+	        <tasks help="tasks to do gw,singlets,triplets or all" default="gw,singlets">gw,singlets</tasks>
+	        <sigma_integrator help="self-energy correlation integration method: ppm, exact" default="ppm">ppm</sigma_integrator>
+	        <eta help="small parameter eta of the Green's function" default="1e-3">1e-3</eta>
+	        <qp_solver help="QP equation solve method: fixedpoint, grid" default="grid">grid</qp_solver>
+	        <qp_grid_steps help="number of QP grid points" default="1001">1001</qp_grid_steps>
+	        <qp_grid_spacing help="spacing of QP grid points in Ha" default="0.001">0.001</qp_grid_spacing>
+	        <exctotal help="maximum number of BSE states to calculate" default="30">30</exctotal>
+	        <useTDA help="use TDA for BSE default `false`" default="0">0</useTDA>
+	        <ignore_corelevels help="exclude core MO level from calculation on RPA,GW or BSE level" default="no">no</ignore_corelevels>
+	        <eigensolver help="options for BSE eigenvalue decompostion">
+	            <dodavidson help="use davidson solver" default="1">1</dodavidson>
+	            <davidson_correction help="DPR or OHLSEN" default="DPR">DPR</davidson_correction>
+	            <davidson_tolerance help="loose,normal,strict" default="strict">strict</davidson_tolerance>
+	            <davidson_ortho help="orthogonalisation routine GS or QR" default="GS">GS</davidson_ortho>
+	            <davidson_update help=" how large the search space can become min, safe, max" default="safe">safe</davidson_update>
+	            <davidson_maxiter help="max iterations" default="50">50</davidson_maxiter>
+	            <domatrixfree help="solve without explicitly setting up BSE matrix, (slower but a lot less memory required" default="0">0</domatrixfree>
+	        </eigensolver>
+	        <gw_sc_max_iterations help="Maximum number of iterations in gvGW" default="50">50</gw_sc_max_iterations>
+	        <gw_mixing_order help="Mixing of QP energies in evGW - 0: plain, 1: linear, >1: Anderson" default="20">20</gw_mixing_order>
+	        <g_sc_max_iterations help="What is this again?" default="100">100</g_sc_max_iterations>
+	        <use_Hqp_offdiagonals help="Using symmetrized off-diagonal elements of QP Hamiltonian in BSE" default="false">false</use_Hqp_offdiagonals>
+        </gwbse>
+    </gwbse_options>
 
+    <bsecoupling help="Exciton couplings from serialized orbital files" section="sec:bsecoupling">
 
+        <spin help="Spin type for couplings, singlet,triplet,all" default="singlet">all</spin>
+        <degeneracy help="Criterium for the degeneracy of two levels" unit="eV" default="0">0</degeneracy>
+
+       <moleculeA help="Properties of molecule A">
+                <states help="Number of excitons considered" default="5">5</states>
+                <occLevels help="occupied levels for CTstates" default="5">5</occLevels>
+                <unoccLevels help="unoccupied levels for CTstates" default="5">5</unoccLevels>
+        </moleculeA>
+
+        <moleculeB help="Properties of molecule B">
+                <states help="Number of excitons considered" default="5">5</states>
+                <occLevels help="occupied levels for CTstates" default="5">5</occLevels>
+                <unoccLevels help="unoccupied levels for CTstates" default="5">5</unoccLevels>
+         </moleculeB>
+
+    </bsecoupling>
+        
+    <dftcoupling_options>
+        <degeneracy help="Criterium for the degeneracy of two levels" unit="eV" default="0">0.0</degeneracy>
+        <levA help="Output HOMO, ..., HOMO-levels; LUMO, ..., LUMO+levels, molecule A">1</levA>
+        <levB help="Output HOMO, ..., HOMO-levels; LUMO, ..., LUMO+levels, molecule B">1</levB>
+    </dftcoupling_options>
+
+    <dftpackage>
+        <package>
+            <name help="Name of the DFT package" default="xtp">xtp</name>
+        </package>
+    </dftpackage>
+
+</iqm>
 
 </options>
 

--- a/share/xtp/xml/qmmm.xml
+++ b/share/xtp/xml/qmmm.xml
@@ -1,45 +1,80 @@
 <options>
     <qmmm help="Executes qmmm calculations for individual molecules and clusters" section="sec:qmmm">
-        <print_regions_pdb help="print the geometry of the regions to a pdb file">true</print_regions_pdb>
-        <max_iterations help="max iterations for qmmm scf loop">50</max_iterations>
-        <map_file help="xml file with segment definition">system.xml</map_file>
-        <job_file help="name of jobfile to which jobs are written">qmmm_jobs.xml</job_file>
+        <print_regions_pdb help="print the geometry of the regions to a pdb file" default="true">true</print_regions_pdb>
+        <max_iterations help="max iterations for qmmm scf loop" default="100">100</max_iterations>
+        <map_file help="xml file with segment definition" default="votca_map.xml">votca_map.xml</map_file>
+        <job_file help="name of jobfile to which jobs are written" default="qmmm_jobs.xml">qmmm_jobs.xml</job_file>
         <write_parse>
-            <states help="states to write jobs for and which to parse from jobfile">n s1 t1</states>
+            <states help="states to write jobs for and which to parse from jobfile" default="n e h">n e h</states>
         </write_parse>
-        
+
         <regions  help="definition of regions in qmmm setup. First region can be a QM region. In each region all options can be also read from a jobfile by the keyword 'jobfile'">
             <region help="definition of a region">
-                <id help="id of a region has to start from 0">0</id>
-                <type help="type of region qm/static/polar">qm</type>
-                <options_dft help="xml file with options for dft calculations">user_input.xml</options_dft>
-                <options_gwbse help="xml file with options for gwbse calculations">gwbse.xml</options_gwbse>
+                <id help="id of a region has to start from 0" default="0">0</id>
+                <type help="type of region qm/static/polar" default="qm">qm</type>
+                <options_dft help="xml file with options for dft calculations">
+                    <package>
+                        <name help="name of dft package" default="xtp">xtp</name>
+                    </package>
+                </options_dft>
+
+                <options_gwbse help="xml file with options for gwbse calculations">
+                <gwbse>
+		            <ranges help="default: all levels in RPA, 1:2*HOMO in QP and all in BSE; other options: factor,explicit">default</ranges>
+	                <rpamax help="only needed, if ranges is factor or explicit, number of levels in rpa" default=""></rpamax>
+	                <qpmin help="only needed, if ranges is factor or explicit, lowest MO to be used in GW" default="" ></qpmin>
+	                <qpmax help="only needed, if ranges is factor or explicit, highest MO to be used in GW" default=""></qpmax>
+	                <bsemin help="only needed, if ranges is factor or explicit, lowest MO to be used in BSE" default=""></bsemin>
+	                <bsemax help="only needed, if ranges is factor or explicit, highest MO to be used in BSE" default=""></bsemax>
+	                <vxc help="Exchange correlation functional computation for GW">
+	                    <grid help="grid quality xcoarse,coarse,medium,fine,xfine" default="medium">medium</grid>
+	                </vxc>
+	                <scissor_shift help="preshift unoccupied MOs by a constant for GW calculation" default="0.0" unit="hartree">0.0</scissor_shift>
+	                <mode help="use single short (G0W0) or self-consistent GW (evGW)" default="evGW">evGW</mode>
+	                <tasks help="tasks to do gw,singlets,triplets or all" default="gw,singlets">gw,singlets</tasks>
+	                <sigma_integrator help="self-energy correlation integration method: ppm, exact" default="ppm">ppm</sigma_integrator>
+	                <eta help="small parameter eta of the Green's function" default="1e-3">1e-3</eta>
+	                <qp_solver help="QP equation solve method: fixedpoint, grid" default="grid">grid</qp_solver>
+	                <qp_grid_steps help="number of QP grid points" default="1001">1001</qp_grid_steps>
+	                <qp_grid_spacing help="spacing of QP grid points in Ha" default="0.001">0.001</qp_grid_spacing>
+	                <exctotal help="maximum number of BSE states to calculate" default="30">30</exctotal>
+	                <useTDA help="use TDA for BSE default `false`" default="0">0</useTDA>
+	                <ignore_corelevels help="exclude core MO level from calculation on RPA,GW or BSE level" default="no">no</ignore_corelevels>
+	                <eigensolver help="options for BSE eigenvalue decompostion">
+	                    <dodavidson help="use davidson solver" default="1">1</dodavidson>
+	                    <davidson_correction help="DPR or OHLSEN" default="DPR">DPR</davidson_correction>
+                        <davidson_tolerance help="loose,normal,strict" default="strict">strict</davidson_tolerance>
+	                    <davidson_ortho help="orthogonalisation routine GS or QR" default="GS">GS</davidson_ortho>
+	                    <davidson_update help=" how large the search space can become min, safe, max" default="safe">safe</davidson_update>
+	                    <davidson_maxiter help="max iterations" default="50">50</davidson_maxiter>
+	                    <domatrixfree help="solve without explicitly setting up BSE matrix, (slower but a lot less memory required" default="0">0</domatrixfree>
+	                </eigensolver>
+	                <gw_sc_max_iterations help="Maximum number of iterations in gvGW" default="50">50</gw_sc_max_iterations>
+	                <gw_mixing_order help="Mixing of QP energies in evGW - 0: plain, 1: linear, >1: Anderson" default="20">20</gw_mixing_order>
+	                <g_sc_max_iterations help="What is this again?" default="100">100</g_sc_max_iterations>
+	                <use_Hqp_offdiagonals help="Using symmetrized off-diagonal elements of QP Hamiltonian in BSE" default="false">false</use_Hqp_offdiagonals>
+                </gwbse>       	    
+                </options_gwbse>
+
                 <statetracker help="filter to identify excited states from some characteristic and not the energy">
-                    <oscillatorstrength>0.5</oscillatorstrength>
+                    <oscillatorstrength default="0.5">0.5</oscillatorstrength>
                 </statetracker>
-                <state help="qmstate to calculate i.e. n or s1">jobfile</state>
-                <segments help="which segments to include in this region and which geometry they have">jobfile</segments>
+                <state help="qmstate to calculate i.e. n or s1" default="jobfile">jobfile</state>
+                <segments help="which segments to include in this region and which geometry they have" default="jobfile">jobfile</segments>
             </region>
             <region>
                 <id>1</id>
                 <type>polar</type>
-                <options_polar help="xml file with options for classical polarized calculations">polar.xml</options_polar>
-                <cutoff help="cutoff to define segments via distance to some segment in the same region or another region">
-                    <relative_to_explicit_segs help="if distance should only be calculated to explicitly stated segments in the region or all which are also in the cutoff">true</relative_to_explicit_segs>
-                    <geometry help="geometry that should be used for these segments">n</geometry>
-                    <radius help="maximum distance to reference to be in region" unit="nm">1</radius>
-                    <region help="region to calculate distance to. Delete if you want to calculate distance to segments in this region" >0</region>
-                </cutoff>
+                <options_polar help="xml file with options for classical polarized calculations">
+                    <tolerance_energy help="Energy change as convergence criterion" default="1e-5">1e-5</tolerance_energy>
+                    <tolerance_dipole help="Field change as convergence criterion" default="1e-5">1e-5</tolerance_dipole>
+                    <max_iter help="Maximum number of iterations" default="51">512</max_iter>
+                    <exp_damp help="Thole sharpness parameter" default="0.39">0.39</exp_damp>
+                </options_polar>
             </region>
             <region>
                 <id>2</id>
                 <type>static</type>
-                <cutoff>
-                    <relative_to_explicit_segs>true</relative_to_explicit_segs>
-                    <geometry>n</geometry>
-                    <radius>1.4</radius>
-                    <region>0</region>
-                </cutoff>
             </region>
         </regions>
     </qmmm>

--- a/src/libxtp/jobcalculators/eqm.h
+++ b/src/libxtp/jobcalculators/eqm.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -21,7 +21,7 @@
 #ifndef _CALC_XTP_EQM_H
 #define _CALC_XTP_EQM_H
 
-#include <votca/xtp/gwbse.h>  // including GWBSE functionality
+#include <votca/xtp/gwbse.h>
 #include <votca/xtp/parallelxjobcalc.h>
 #include <votca/xtp/qmpackagefactory.h>
 #include <votca/xtp/segment.h>
@@ -30,12 +30,11 @@ namespace votca {
 namespace xtp {
 
 /**
- * \brief GWBSE implementation
+ * \brief Run DFT/GWBSE calculations
  *
  * Evaluates DFT and GWBSE for all molecules
  * Requires a first-principles package, i.e. ORCA
  *
- * Callname: eqm
  */
 
 class EQM : public ParallelXJobCalc<std::vector<Job> > {
@@ -54,21 +53,20 @@ class EQM : public ParallelXJobCalc<std::vector<Job> > {
 
   void SetJobToFailed(Job::JobResult &jres, Logger &pLog,
                       const std::string &errormessage);
-  void ParseOptionsXML(tools::Property &options);
 
   tools::Property _package_options;
   tools::Property _gwbse_options;
   tools::Property _esp_options;
 
   // what to do
-  bool _do_dft_input;
-  bool _do_dft_run;
-  bool _do_dft_parse;
-  bool _do_gwbse;
-  bool _do_esp;
+  bool _do_dft_input = false;
+  bool _do_dft_run = false;
+  bool _do_dft_parse = false;
+  bool _do_gwbse = false;
+  bool _do_esp = false;
 };
 
 }  // namespace xtp
 }  // namespace votca
 
-#endif /* _CALC_GWBSE_TOOL_H */
+#endif

--- a/src/libxtp/jobcalculators/iexcitoncl.cc
+++ b/src/libxtp/jobcalculators/iexcitoncl.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -27,7 +27,6 @@
 #include <votca/xtp/eeinteractor.h>
 #include <votca/xtp/logger.h>
 
-using namespace std;
 using namespace boost::filesystem;
 using namespace votca::tools;
 
@@ -38,36 +37,34 @@ namespace xtp {
 // IEXCITON MEMBER FUNCTIONS         //
 // +++++++++++++++++++++++++++++ //
 
-void IEXCITON::Initialize(tools::Property& options) {
+void IEXCITON::Initialize(tools::Property& user_options) {
 
-  string key = "options." + Identify();
-  ParseCommonOptions(options);
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
+  ParseCommonOptions();
 
-  if (options.exists(key + ".states")) {
-    string parse_string = options.get(key + ".states").as<string>();
+  if (_options.exists(".states")) {
+    std::string parse_string = _options.get(".states").as<std::string>();
     _statemap = FillParseMaps(parse_string);
   }
-
-  cout << "done" << endl;
 }
 
 std::map<std::string, QMState> IEXCITON::FillParseMaps(
-    const string& Mapstring) {
+    const std::string& Mapstring) {
   Tokenizer split_options(Mapstring, ", \t\n");
   std::map<std::string, QMState> type2level;
-  for (const string& substring : split_options) {
-    std::vector<string> segmentpnumber;
+  for (const std::string& substring : split_options) {
+    std::vector<std::string> segmentpnumber;
     Tokenizer tok(substring, ":");
     tok.ToVector(segmentpnumber);
     if (segmentpnumber.size() != 2) {
-      throw runtime_error("Parser iqm: Segment and exciton labels:" +
-                          substring + "are not separated properly");
+      throw std::runtime_error("Parser iqm: Segment and exciton labels:" +
+                               substring + "are not separated properly");
     }
     QMState state = QMState(segmentpnumber[1]);
     if (!state.isTransition()) {
       throw std::runtime_error("State to calculate must be a transition state");
     }
-    string segmentname = segmentpnumber[0];
+    std::string segmentname = segmentpnumber[0];
     type2level[segmentname] = state;
   }
   return type2level;
@@ -85,25 +82,27 @@ Job::JobResult IEXCITON::EvalJob(const Topology& top, Job& job,
   // get the information about the job executed by the thread
   Index job_ID = job.getId();
   Property job_input = job.getInput();
-  vector<Property*> segment_list = job_input.Select("segment");
+  std::vector<Property*> segment_list = job_input.Select("segment");
   Index ID_A = segment_list.front()->getAttribute<Index>("id");
-  string type_A = segment_list.front()->getAttribute<string>("type");
-  string mps_fileA = segment_list.front()->getAttribute<string>("mps_file");
+  std::string type_A = segment_list.front()->getAttribute<std::string>("type");
+  std::string mps_fileA =
+      segment_list.front()->getAttribute<std::string>("mps_file");
   Index ID_B = segment_list.back()->getAttribute<Index>("id");
-  string type_B = segment_list.back()->getAttribute<string>("type");
-  string mps_fileB = segment_list.back()->getAttribute<string>("mps_file");
+  std::string type_B = segment_list.back()->getAttribute<std::string>("type");
+  std::string mps_fileB =
+      segment_list.back()->getAttribute<std::string>("mps_file");
 
   const Segment& seg_A = top.getSegment(ID_A);
   if (type_A != seg_A.getType()) {
-    throw runtime_error("SegmentA: type " + seg_A.getType() +
-                        " and type in jobfile " + type_A +
-                        " do not agree for ID:" + std::to_string(ID_A));
+    throw std::runtime_error("SegmentA: type " + seg_A.getType() +
+                             " and type in jobfile " + type_A +
+                             " do not agree for ID:" + std::to_string(ID_A));
   }
   const Segment& seg_B = top.getSegment(ID_B);
   if (type_B != seg_B.getType()) {
-    throw runtime_error("SegmentB: type " + seg_B.getType() +
-                        " and type in jobfile " + type_B +
-                        " do not agree for ID:" + std::to_string(ID_B));
+    throw std::runtime_error("SegmentB: type " + seg_B.getType() +
+                             " and type in jobfile " + type_B +
+                             " do not agree for ID:" + std::to_string(ID_B));
   }
   const QMNBList& nblist = top.NBList();
   const QMPair* pair = nblist.FindPair(&seg_A, &seg_B);
@@ -114,7 +113,7 @@ Job::JobResult IEXCITON::EvalJob(const Topology& top, Job& job,
   }
 
   XTP_LOG(Log::error, pLog) << TimeStamp() << " Evaluating pair " << job_ID
-                            << " [" << ID_A << ":" << ID_B << "]" << flush;
+                            << " [" << ID_A << ":" << ID_B << "]" << std::flush;
 
   StaticMapper map(pLog);
   map.LoadMappingFile(_mapfile);
@@ -126,8 +125,8 @@ Job::JobResult IEXCITON::EvalJob(const Topology& top, Job& job,
   Property job_summary;
   Property& job_output = job_summary.add("output", "");
   Property& pair_summary = job_output.add("pair", "");
-  string nameA = seg_A.getType();
-  string nameB = seg_B.getType();
+  std::string nameA = seg_A.getType();
+  std::string nameB = seg_B.getType();
   pair_summary.setAttribute("idA", ID_A);
   pair_summary.setAttribute("idB", ID_B);
   pair_summary.setAttribute("typeA", nameA);
@@ -159,51 +158,51 @@ QMState IEXCITON::GetElementFromMap(const std::string& elementname) const {
 
 void IEXCITON::WriteJobFile(const Topology& top) {
 
-  cout << endl << "... ... Writing job file " << _jobfile << flush;
+  std::cout << "\n... ... Writing job file " << _jobfile << std::flush;
   std::ofstream ofs;
   ofs.open(_jobfile, std::ofstream::out);
   if (!ofs.is_open()) {
-    throw runtime_error("\nERROR: bad file handle: " + _jobfile);
+    throw std::runtime_error("\nERROR: bad file handle: " + _jobfile);
   }
   const QMNBList& nblist = top.NBList();
   Index jobCount = 0;
   if (nblist.size() == 0) {
-    cout << endl << "... ... No pairs in neighbor list, skip." << flush;
+    std::cout << "\n... ... No pairs in neighbor list, skip." << std::flush;
     return;
   }
 
-  ofs << "<jobs>" << endl;
-  string tag = "";
+  ofs << "<jobs>\n";
+  std::string tag = "";
 
   for (const QMPair* pair : nblist) {
     if (pair->getType() == QMPair::PairType::Excitoncl) {
       Index id1 = pair->Seg1()->getId();
-      string name1 = pair->Seg1()->getType();
+      std::string name1 = pair->Seg1()->getType();
       Index id2 = pair->Seg2()->getId();
-      string name2 = pair->Seg2()->getType();
+      std::string name2 = pair->Seg2()->getType();
       Index id = jobCount;
       QMState state1 = GetElementFromMap(name1);
       QMState state2 = GetElementFromMap(name2);
 
-      string mps_file1 =
+      std::string mps_file1 =
           (boost::format("MP_FILES/%s_%s.mps") % name1 % state1.ToString())
               .str();
-      string mps_file2 =
+      std::string mps_file2 =
           (boost::format("MP_FILES/%s_%s.mps") % name2 % state2.ToString())
               .str();
 
       Property Input;
       Property& pInput = Input.add("input", "");
       Property& pSegment1 =
-          pInput.add("segment", boost::lexical_cast<string>(id1));
-      pSegment1.setAttribute<string>("type", name1);
+          pInput.add("segment", boost::lexical_cast<std::string>(id1));
+      pSegment1.setAttribute<std::string>("type", name1);
       pSegment1.setAttribute<Index>("id", id1);
-      pSegment1.setAttribute<string>("mps_file", mps_file1);
+      pSegment1.setAttribute<std::string>("mps_file", mps_file1);
       Property& pSegment2 =
-          pInput.add("segment", boost::lexical_cast<string>(id2));
-      pSegment2.setAttribute<string>("type", name2);
+          pInput.add("segment", boost::lexical_cast<std::string>(id2));
+      pSegment2.setAttribute<std::string>("type", name2);
       pSegment2.setAttribute<Index>("id", id2);
-      pSegment2.setAttribute<string>("mps_file", mps_file2);
+      pSegment2.setAttribute<std::string>("mps_file", mps_file2);
 
       Job job(id, tag, Input, Job::AVAILABLE);
       job.ToStream(ofs);
@@ -212,16 +211,16 @@ void IEXCITON::WriteJobFile(const Topology& top) {
   }
 
   // CLOSE STREAM
-  ofs << "</jobs>" << endl;
+  ofs << "</jobs>\n";
   ofs.close();
 
-  cout << endl << "... ... In total " << jobCount << " jobs" << flush;
+  std::cout << "\n... ... In total " << jobCount << " jobs" << std::flush;
 }
 
 void IEXCITON::ReadJobFile(Topology& top) {
 
   Property xml;
-  vector<Property*> records;
+  std::vector<Property*> records;
   // gets the neighborlist from the topology
   QMNBList& nblist = top.NBList();
   Index number_of_pairs = nblist.size();
@@ -231,7 +230,7 @@ void IEXCITON::ReadJobFile(Topology& top) {
 
   // load the QC results in a vector indexed by the pair ID
   xml.LoadFromXML(_jobfile);
-  vector<Property*> jobProps = xml.Select("jobs.job");
+  std::vector<Property*> jobProps = xml.Select("jobs.job");
   records.resize(number_of_pairs + 1);
 
   // to skip pairs which are not in the jobfile
@@ -253,22 +252,23 @@ void IEXCITON::ReadJobFile(Topology& top) {
       if (qmp == nullptr) {
         XTP_LOG(Log::error, log)
             << "No pair " << idA << ":" << idB
-            << " found in the neighbor list. Ignoring" << flush;
+            << " found in the neighbor list. Ignoring" << std::flush;
       } else {
         records[qmp->getId()] = &(prop->get("output.pair"));
       }
     } else {
       Property thebadone = prop->get("id");
-      throw runtime_error("\nERROR: Job file incomplete.\n Job with id " +
-                          thebadone.as<string>() +
-                          " is not finished. Check your job file for FAIL, "
-                          "AVAILABLE, or ASSIGNED. Exiting\n");
+      throw std::runtime_error(
+          "\nERROR: Job file incomplete.\n Job with id " +
+          thebadone.as<std::string>() +
+          " is not finished. Check your job file for FAIL, "
+          "AVAILABLE, or ASSIGNED. Exiting\n");
     }
   }  // finished loading from the file
 
   // loop over all pairs in the neighbor list
   XTP_LOG(Log::error, log) << "Neighborlist size " << top.NBList().size()
-                           << flush;
+                           << std::flush;
   for (QMPair* pair : top.NBList()) {
 
     if (records[pair->getId()] == nullptr) {
@@ -284,8 +284,8 @@ void IEXCITON::ReadJobFile(Topology& top) {
     }
   }
   XTP_LOG(Log::error, log) << "Pairs [total:updated] " << number_of_pairs << ":"
-                           << current_pairs << flush;
-  cout << log;
+                           << current_pairs << std::flush;
+  std::cout << log;
 }
 
 }  // namespace xtp

--- a/src/libxtp/jobcalculators/iexcitoncl.h
+++ b/src/libxtp/jobcalculators/iexcitoncl.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")

--- a/src/libxtp/jobcalculators/iqm.cc
+++ b/src/libxtp/jobcalculators/iqm.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -35,23 +35,19 @@ using namespace boost::filesystem;
 namespace votca {
 namespace xtp {
 
-void IQM::Initialize(tools::Property& options) {
-  ParseOptionsXML(options);
+void IQM::Initialize(tools::Property& user_options) {
 
-  // register all QM packages (Orca)
+  LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
+  ParseCommonOptions();
   QMPackageFactory::RegisterAll();
-  return;
+
+  ParseOptionsXML();
 }
 
-void IQM::ParseOptionsXML(tools::Property& opt) {
-
-  ParseCommonOptions(opt);
-  // parsing general ibse options
-  std::string key = "options." + Identify();
-  // _energy_difference = opt.get( key + ".degeneracy" ).as< double > ();
+void IQM::ParseOptionsXML() {
 
   // job tasks
-  std::string tasks_string = opt.get(key + ".tasks").as<std::string>();
+  std::string tasks_string = _options.get(".tasks").as<std::string>();
   if (tasks_string.find("input") != std::string::npos) {
     _do_dft_input = true;
   }
@@ -72,7 +68,7 @@ void IQM::ParseOptionsXML(tools::Property& opt) {
   }
 
   // storage options
-  std::string store_string = opt.get(key + ".store").as<std::string>();
+  std::string store_string = _options.get(".store").as<std::string>();
   if (store_string.find("dft") != std::string::npos) {
     _store_dft = true;
   }
@@ -80,14 +76,14 @@ void IQM::ParseOptionsXML(tools::Property& opt) {
     _store_gw = true;
   }
 
-  if (_do_dft_input || _do_dft_run || _do_dft_parse) {
-    std::string package_xml = opt.get(key + ".dftpackage").as<std::string>();
-    _dftpackage_options.LoadFromXML(package_xml);
-  }
+  _dftpackage_options = _options.get(".dftpackage");
+  _gwbse_options = _options.get(".gwbse_options");
+  _dftcoupling_options = _options.get(".dftcoupling_options");
+  _bsecoupling_options = _options.get(".bsecoupling_options");
 
   // read linker groups
-  std::string linker = opt.ifExistsReturnElseReturnDefault<std::string>(
-      key + ".linker_names", "");
+  std::string linker = _options.ifExistsReturnElseReturnDefault<std::string>(
+      ".linker_names", "");
   tools::Tokenizer toker(linker, ", \t\n");
   std::vector<std::string> linkers = toker.ToVector();
   for (const std::string& link : linkers) {
@@ -100,45 +96,29 @@ void IQM::ParseOptionsXML(tools::Property& opt) {
     _linkers[link_split[0]] = QMState(link_split[1]);
   }
 
-  if (_do_dftcoupling) {
-    _dftcoupling_options = opt.get(key + ".dftcoupling_options");
-  }
-
-  if (_do_gwbse) {
-    std::string _gwbse_xml = opt.get(key + ".gwbse_options").as<std::string>();
-
-    _gwbse_options.LoadFromXML(_gwbse_xml);
-  }
-  if (_do_bsecoupling) {
-    std::string _coupling_xml =
-        opt.get(key + ".bsecoupling_options").as<std::string>();
-    _bsecoupling_options.LoadFromXML(_coupling_xml);
-  }
-
   // options for parsing data into state file
   std::string key_read = "options." + Identify() + ".readjobfile";
-  if (opt.exists(key_read + ".singlet")) {
+  if (_options.exists(key_read + ".singlet")) {
     std::string parse_string_s =
-        opt.get(key_read + ".singlet").as<std::string>();
+        _options.get(key_read + ".singlet").as<std::string>();
     _singlet_levels = FillParseMaps(parse_string_s);
   }
-  if (opt.exists(key_read + ".triplet")) {
+  if (_options.exists(key_read + ".triplet")) {
     std::string parse_string_t =
-        opt.get(key_read + ".triplet").as<std::string>();
+        _options.get(key_read + ".triplet").as<std::string>();
     _triplet_levels = FillParseMaps(parse_string_t);
   }
 
-  if (opt.exists(key_read + ".hole")) {
-    std::string parse_string_h = opt.get(key_read + ".hole").as<std::string>();
+  if (_options.exists(key_read + ".hole")) {
+    std::string parse_string_h =
+        _options.get(key_read + ".hole").as<std::string>();
     _hole_levels = FillParseMaps(parse_string_h);
   }
-  if (opt.exists(key_read + ".electron")) {
+  if (_options.exists(key_read + ".electron")) {
     std::string parse_string_e =
-        opt.get(key_read + ".electron").as<std::string>();
+        _options.get(key_read + ".electron").as<std::string>();
     _electron_levels = FillParseMaps(parse_string_e);
   }
-
-  return;
 }
 
 std::map<std::string, QMState> IQM::FillParseMaps(
@@ -175,7 +155,6 @@ void IQM::addLinkers(std::vector<const Segment*>& segments,
       segments.push_back(segment);
     }
   }
-  return;
 }
 
 bool IQM::isLinker(const std::string& name) {

--- a/src/libxtp/jobcalculators/iqm.h
+++ b/src/libxtp/jobcalculators/iqm.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -63,7 +63,7 @@ class IQM : public ParallelXJobCalc<std::vector<Job> > {
   void WriteLoggerToFile(const std::string& logfile, Logger& logger);
   void addLinkers(std::vector<const Segment*>& segments, const Topology& top);
   bool isLinker(const std::string& name);
-  void ParseOptionsXML(tools::Property& opt);
+  void ParseOptionsXML();
   std::map<std::string, QMState> FillParseMaps(const std::string& Mapstring);
 
   QMState GetElementFromMap(const std::map<std::string, QMState>& elementmap,

--- a/src/libxtp/jobcalculators/qmmm.h
+++ b/src/libxtp/jobcalculators/qmmm.h
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -47,13 +47,13 @@ class QMMM : public ParallelXJobCalc<std::vector<Job> > {
   bool hasQMRegion() const;
   tools::Property _regions_def;
 
-  Index _max_iterations = 100;
+  Index _max_iterations;
   bool _print_regions_pdb = false;
 
-  bool _write_parse = false;
+  bool _write_parse = true;
   std::vector<QMState> _states;
 };
 
 }  // namespace xtp
 }  // namespace votca
-#endif
+#endif  // VOTCA_XTP_QMMM_H

--- a/src/libxtp/parallelxjobcalc.cc
+++ b/src/libxtp/parallelxjobcalc.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -97,24 +97,19 @@ void ParallelXJobCalc<JobContainer>::JobOperator::Run() {
 }
 
 template <typename JobContainer>
-void ParallelXJobCalc<JobContainer>::ParseCommonOptions(
-    const tools::Property &options) {
-  std::cout << std::endl
-            << "... ... Initialized with " << _nThreads << " threads. "
-            << std::flush;
+void ParallelXJobCalc<JobContainer>::ParseCommonOptions() {
+  std::cout << "\n... ... Initialized with " << _nThreads << " threads.\n";
 
   _maverick = (_nThreads == 1) ? true : false;
 
-  std::string key = "options." + Identify();
-  std::cout << std::endl
-            << "... ... Using " << _openmp_threads << " openmp threads for "
+  std::cout << "\n... ... Using " << _openmp_threads << " openmp threads for "
             << _nThreads << "x" << _openmp_threads << "="
             << _nThreads * _openmp_threads << " total threads." << std::flush;
   OPENMP::setMaxThreads(_openmp_threads);
-  _jobfile = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".job_file");
-  _mapfile = options.ifExistsReturnElseThrowRuntimeError<std::string>(
-      key + ".map_file");
+  _jobfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".job_file");
+  _mapfile =
+      _options.ifExistsReturnElseThrowRuntimeError<std::string>(".map_file");
 }
 
 template <typename JobContainer>


### PR DESCRIPTION
See: #319

## Changed
* For the `xtp_parallel` calculator the options file is no longer mandatory.
* Changed signature for `ParallelXJobCalc<JobContainer>::ParseCommonOptions` method

**Calculators**:
* [x] eqm
* [x] iexcitoncl
* [x] iqm
* [x] qmmm