### PR TITLE
mv bsecoupling defaults to the xml files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ For more detailed information about the changes see the history of the
 * add documentation using Sphinx (#433)
 * add kokkos-based Ewald solver (#444, #446)
 * allow multiple choices for the calculator options (#442, #445)
+* move bsecoupling defaults to xml (#451)
 
 ## Version 1.6.1 (released XX.04.20)
 * fix warnings on Ubuntu 20.04 (#438)

--- a/include/votca/xtp/bsecoupling.h
+++ b/include/votca/xtp/bsecoupling.h
@@ -97,10 +97,10 @@ class BSECoupling : public CouplingBase {
   bool _output_perturbation = true;
   Index _levA;
   Index _levB;
-  Index _occA = 5;
-  Index _unoccA = 5;
-  Index _occB = 5;
-  Index _unoccB = 5;
+  Index _occA;
+  Index _unoccA;
+  Index _occB;
+  Index _unoccB;
 };
 
 }  // namespace xtp

--- a/share/xtp/xml/eqm.xml
+++ b/share/xtp/xml/eqm.xml
@@ -20,7 +20,7 @@
         </vxc>
         <scissor_shift help="preshift unoccupied MOs by a constant for GW calculation" default="0.0" unit="hartree" choices="float"/>
         <mode help="use single short (G0W0) or self-consistent GW (evGW)" default="evGW" choices="evGW,G0W0"/>
-        <tasks help="tasks to do" default="gw,singlets" choices="[gw,singlets,triplets,all]"/>
+        <tasks help="tasks to do" default="all" choices="[gw,singlets,triplets,all]"/>
         <sigma_integrator help="self-energy correlation integration method" default="ppm" choices="ppm, exact"/>
         <eta help="small parameter eta of the Green's function" default="1e-3" unit="Hartree" choices="float+"/>
         <qp_solver help="QP equation solve method" default="grid" choices="fixedpoint,grid"/>

--- a/share/xtp/xml/iqm.xml
+++ b/share/xtp/xml/iqm.xml
@@ -21,7 +21,7 @@
         </vxc>
         <scissor_shift help="preshift unoccupied MOs by a constant for GW calculation" default="0.0" unit="hartree" choices="float"/>
         <mode help="use single short (G0W0) or self-consistent GW (evGW)" default="evGW" choices="evGW,G0W0"/>
-        <tasks help="tasks to do" default="gw,singlets" choices="[gw,singlets,triplets,all]"/>
+        <tasks help="tasks to do" default="all" choices="[gw,singlets,triplets,all]"/>
         <sigma_integrator help="self-energy correlation integration method" default="ppm" choices="ppm, exact"/>
         <eta help="small parameter eta of the Green's function" default="1e-3" unit="Hartree" choices="float+"/>
         <qp_solver help="QP equation solve method" default="grid" choices="fixedpoint,grid"/>

--- a/src/libxtp/bsecoupling.cc
+++ b/src/libxtp/bsecoupling.cc
@@ -54,18 +54,12 @@ void BSECoupling::Initialize(Property& options) {
   _output_perturbation = options.ifExistsReturnElseReturnDefault<bool>(
       key + ".use_perturbation", _output_perturbation);
 
-  _levA =
-      options.ifExistsReturnElseReturnDefault(key + ".moleculeA.states", _levA);
-  _levB =
-      options.ifExistsReturnElseReturnDefault(key + ".moleculeB.states", _levB);
-  _occA = options.ifExistsReturnElseReturnDefault(key + ".moleculeA.occLevels",
-                                                  _occA);
-  _occB = options.ifExistsReturnElseReturnDefault(key + ".moleculeB.occLevels",
-                                                  _occB);
-  _unoccA = options.ifExistsReturnElseReturnDefault(
-      key + ".moleculeA.unoccLevels", _unoccA);
-  _unoccB = options.ifExistsReturnElseReturnDefault(
-      key + ".moleculeB.unoccLevels", _unoccB);
+  _levA = options.get(key + ".moleculeA.states").as<Index>();
+  _levB = options.get(key + ".moleculeB.states").as<Index>();
+  _occA = options.get(key + ".moleculeA.occLevels").as<Index>();
+  _occB = options.get(key + ".moleculeB.occLevels").as<Index>();
+  _unoccA = options.get(key + ".moleculeA.unoccLevels").as<Index>();
+  _unoccB = options.get(key + ".moleculeB.unoccLevels").as<Index>();
 }
 
 void BSECoupling::WriteToProperty(Property& summary, const QMState& stateA,
@@ -437,7 +431,6 @@ void BSECoupling::CalculateCouplings(const Orbitals& orbitalsA,
   opt.useTDA = true;
   opt.vmin = orbitalsAB.getBSEvmin();
   opt.use_Hqp_offdiag = orbitalsAB.GetFlagUseHqpOffdiag();
-
   BSE bse(*_pLog, Mmn);
   bse.configure(opt, orbitalsAB.RPAInputEnergies(), Hqp);
   XTP_LOG(Log::error, *_pLog) << TimeStamp() << " Setup BSE operator" << flush;
@@ -464,7 +457,6 @@ void BSECoupling::CalculateCouplings(const Orbitals& orbitalsA,
     XTP_LOG(Log::error, *_pLog)
         << TimeStamp() << "   calculated singlet couplings " << flush;
   }
-
   if (_doTriplets) {
     XTP_LOG(Log::error, *_pLog)
         << TimeStamp() << "   Evaluating triplets" << flush;
@@ -484,10 +476,8 @@ void BSECoupling::CalculateCouplings(const Orbitals& orbitalsA,
     XTP_LOG(Log::error, *_pLog)
         << TimeStamp() << "   calculated triplet couplings " << flush;
   }
-
   XTP_LOG(Log::error, *_pLog)
       << TimeStamp() << "  Done with exciton couplings" << flush;
-  return;
 }
 
 Eigen::MatrixXd BSECoupling::OrthogonalizeCTs(Eigen::MatrixXd& FE_AB,


### PR DESCRIPTION
## Proposed changes
Remove the default values from the header file of `bsecoupling`  into the Calculator XML files (e.g. `iqm`)