### PR TITLE
using reductions instead of handcrafted resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ For more detailed information about the changes see the history of the
 * address missing includes (#452)
 * fix readjobfiles path (#453)
 * standardising include order and style in header files (#448)
+* changed to OpenMP reductions instead of hand crafted solutions (#466)
 
 ## Version 1.6.1 (released XX.04.20)
 * fix warnings on Ubuntu 20.04 (#438, #460)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,12 +33,9 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
-find_package(OpenMP)
+find_package(OpenMP 4.5)
 set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Used for thread parallelization in xtp")
-if (OPENMP_FOUND)
-    set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
+
 
 ########################################################################
 # User input options                                                   #

--- a/include/votca/xtp/dipoledipoleinteraction.h
+++ b/include/votca/xtp/dipoledipoleinteraction.h
@@ -123,29 +123,20 @@ class DipoleDipoleInteraction
     assert(v.size() == _size &&
            "input vector has the wrong size for multiply with operator");
     const Index segment_size = Index(_sites.size());
-    std::vector<Eigen::VectorXd> thread_result(OPENMP::getMaxThreads(),
-                                               Eigen::VectorXd::Zero(_size));
-#pragma omp parallel for schedule(dynamic)
+    Eigen::VectorXd result = Eigen::VectorXd::Zero(_size);
+#pragma omp parallel for schedule(dynamic) reduction(+ : result)
     for (Index i = 0; i < segment_size; i++) {
       const PolarSite& site1 = *_sites[i];
+      result.segment<3>(3 * i) += site1.getPInv() * v.segment<3>(3 * i);
       for (Index j = i + 1; j < segment_size; j++) {
         const PolarSite& site2 = *_sites[j];
         Eigen::Matrix3d block = _interactor.FillTholeInteraction(site1, site2);
-        thread_result[OPENMP::getThreadId()].segment<3>(3 * i) +=
-            block * v.segment<3>(3 * j);
-        thread_result[OPENMP::getThreadId()].segment<3>(3 * j) +=
-            block.transpose() * v.segment<3>(3 * i);
+        result.segment<3>(3 * i) += block * v.segment<3>(3 * j);
+        result.segment<3>(3 * j) += block.transpose() * v.segment<3>(3 * i);
       }
     }
-#pragma omp parallel for schedule(dynamic)
-    for (Index i = 0; i < segment_size; i++) {
-      const PolarSite& site = *_sites[i];
-      thread_result[OPENMP::getThreadId()].segment<3>(3 * i) +=
-          site.getPInv() * v.segment<3>(3 * i);
-    }
 
-    return std::accumulate(thread_result.begin(), thread_result.end(),
-                           Eigen::VectorXd::Zero(_size).eval());
+    return result;
   }
 
  private:

--- a/include/votca/xtp/eigen.h
+++ b/include/votca/xtp/eigen.h
@@ -45,6 +45,13 @@ class Mat_p_Energy {
   Mat_p_Energy(double e, Eigen::MatrixXd&& mat)
       : _energy(e), _matrix(std::move(mat)){};
 
+  Mat_p_Energy operator+(const Mat_p_Energy& other) const {
+    Mat_p_Energy result = *this;
+    result._energy += other._energy;
+    result._matrix += other._matrix;
+    return result;
+  }
+
   Index rows() const { return _matrix.rows(); }
   Index cols() const { return _matrix.cols(); }
   Eigen::MatrixXd& matrix() { return _matrix; }
@@ -56,6 +63,21 @@ class Mat_p_Energy {
   double _energy;
   Eigen::MatrixXd _matrix;
 };
+
+#pragma omp declare reduction (+:Mat_p_Energy: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Mat_p_Energy(omp_orig.rows(),omp_orig.cols()))
+
+#pragma omp declare reduction (+: Eigen::VectorXd: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Eigen::VectorXd::Zero(omp_orig.size()))
+
+#pragma omp declare reduction (+: Eigen::MatrixXd: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Eigen::MatrixXd::Zero(omp_orig.rows(),omp_orig.cols()))
+
+#pragma omp declare reduction (+: Eigen::Matrix3d: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Eigen::Matrix3d::Zero())
+
+#pragma omp declare reduction (+: Eigen::Vector3d: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Eigen::Vector3d::Zero())
 
 namespace OPENMP {
 inline Index getMaxThreads() {

--- a/include/votca/xtp/matrixfreeoperator.h
+++ b/include/votca/xtp/matrixfreeoperator.h
@@ -166,27 +166,25 @@ struct generic_product_impl<votca::xtp::MatrixFreeOperator, Mtype, DenseShape,
       Index blocks = op.size() / blocksize;
       // this uses the fact that all our matrices are symmetric, i.e we can
       // reuse half the blocks
-      std::vector<Eigen::MatrixXd> thread_wiseresult(
-          votca::xtp::OPENMP::getMaxThreads(),
-          Eigen::MatrixXd::Zero(dst.rows(), dst.cols()));
-#pragma omp parallel for schedule(guided)
+      Eigen::MatrixXd result = Eigen::MatrixXd::Zero(dst.rows(), dst.cols());
+
+#pragma omp declare reduction (+: Eigen::MatrixXd: omp_out=omp_out+omp_in)\
+     initializer(omp_priv=Eigen::MatrixXd::Zero(omp_orig.rows(),omp_orig.cols()))
+#pragma omp parallel for schedule(guided) reduction(+ : result)
       for (Index i_row = 0; i_row < blocks; i_row++) {
         for (Index i_col = i_row; i_col < blocks; i_col++) {
-          Eigen::MatrixXd blockmat = op.OperatorBlock(i_row, i_col);
-          thread_wiseresult[votca::xtp::OPENMP::getThreadId()].block(
-              i_row * blocksize, 0, blocksize, dst.cols()) +=
+          const Eigen::MatrixXd blockmat = op.OperatorBlock(i_row, i_col);
+          result.block(i_row * blocksize, 0, blocksize, dst.cols()) +=
               blockmat * m.block(i_col * blocksize, 0, blocksize, m.cols());
           if (i_row != i_col) {
-            thread_wiseresult[votca::xtp::OPENMP::getThreadId()].block(
-                i_col * blocksize, 0, blocksize, dst.cols()) +=
+            result.block(i_col * blocksize, 0, blocksize, dst.cols()) +=
                 blockmat.transpose() *
                 m.block(i_row * blocksize, 0, blocksize, m.cols());
           }
         }
       }
-      for (const Eigen::MatrixXd& mat : thread_wiseresult) {
-        dst += mat;
-      }
+
+      dst += result;
     }
   }
 };

--- a/include/votca/xtp/orbitals.h
+++ b/include/votca/xtp/orbitals.h
@@ -367,7 +367,6 @@ class Orbitals {
 
   Index _qpmin = 0;
   Index _qpmax = 0;
-
   Index _bse_vmin = 0;
   Index _bse_vmax = 0;
   Index _bse_cmin = 0;

--- a/include/votca/xtp/qmtool.h
+++ b/include/votca/xtp/qmtool.h
@@ -41,6 +41,8 @@ class QMTool : public tools::Calculator {
   std::string Identify() override = 0;
   void Initialize(const tools::Property &options) override = 0;
   virtual bool Evaluate() = 0;
+
+ protected:
   std::string _job_name = "votca";
 };
 

--- a/src/libxtp/CMakeLists.txt
+++ b/src/libxtp/CMakeLists.txt
@@ -10,7 +10,11 @@ list(REMOVE_ITEM VOTCA_SOURCES ${NOT_VOTCA_SOURCES})
 add_library(votca_xtp  ${VOTCA_SOURCES})
 set_target_properties(votca_xtp PROPERTIES SOVERSION ${SOVERSION})
 add_dependencies(votca_xtp gitversion-xtp)
-target_link_libraries(votca_xtp PUBLIC VOTCA::votca_csg VOTCA::votca_tools Boost::boost Eigen3::Eigen ${HDF5_LIBRARIES} PRIVATE LIBXC::LIBXC Boost::program_options Boost::filesystem Boost::system Boost::timer )
+target_link_libraries(votca_xtp PUBLIC VOTCA::votca_csg VOTCA::votca_tools Boost::boost  Eigen3::Eigen ${HDF5_LIBRARIES} PRIVATE LIBXC::LIBXC Boost::program_options Boost::filesystem Boost::system Boost::timer )
+
+if(TARGET OpenMP::OpenMP_CXX)
+  target_link_libraries(votca_xtp PUBLIC OpenMP::OpenMP_CXX)
+endif()
 
 if(USE_CUDA)
   target_link_libraries(votca_xtp PUBLIC ${CUDA_LIBRARIES} ${CUDA_CUBLAS_LIBRARIES})

--- a/src/libxtp/dftengine/ERIs.cc
+++ b/src/libxtp/dftengine/ERIs.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -42,23 +42,17 @@ void ERIs::Initialize_4c_screening(const AOBasis& dftbasis, double eps) {
 }
 
 Mat_p_Energy ERIs::CalculateERIs(const Eigen::MatrixXd& DMAT) const {
-  Index nthreads = OPENMP::getMaxThreads();
-  std::vector<Eigen::MatrixXd> ERIS_thread = std::vector<Eigen::MatrixXd>(
-      nthreads, Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()));
+  Eigen::MatrixXd ERIs2 = Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols());
   Symmetric_Matrix dmat_sym = Symmetric_Matrix(DMAT);
-#pragma omp parallel for
+#pragma omp parallel for schedule(guided) reduction(+ : ERIs2)
   for (Index i = 0; i < _threecenter.size(); i++) {
     const Symmetric_Matrix& threecenter = _threecenter[i];
     // Trace over prod::DMAT,I(l)=componentwise product over
     const double factor = threecenter.TraceofProd(dmat_sym);
     Eigen::SelfAdjointView<Eigen::MatrixXd, Eigen::Upper> m =
-        ERIS_thread[OPENMP::getThreadId()].selfadjointView<Eigen::Upper>();
+        ERIs2.selfadjointView<Eigen::Upper>();
     threecenter.AddtoEigenUpperMatrix(m, factor);
   }
-
-  Eigen::MatrixXd ERIs2 =
-      std::accumulate(ERIS_thread.begin(), ERIS_thread.end(),
-                      Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()).eval());
 
   ERIs2 = ERIs2.selfadjointView<Eigen::Upper>();
   double energy = CalculateEnergy(DMAT, ERIs2);
@@ -67,45 +61,35 @@ Mat_p_Energy ERIs::CalculateERIs(const Eigen::MatrixXd& DMAT) const {
 
 Mat_p_Energy ERIs::CalculateEXX(const Eigen::MatrixXd& DMAT) const {
 
-  std::vector<Eigen::MatrixXd> EXX_thread = std::vector<Eigen::MatrixXd>(
-      OPENMP::getMaxThreads(), Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()));
+  Eigen::MatrixXd EXX = Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols());
 
-#pragma omp parallel for
+#pragma omp parallel for schedule(guided) reduction(+ : EXX)
   for (Index i = 0; i < _threecenter.size(); i++) {
     const Eigen::MatrixXd threecenter = _threecenter[i].UpperMatrix();
-    EXX_thread[OPENMP::getThreadId()] +=
-        threecenter.selfadjointView<Eigen::Upper>() * DMAT *
-        threecenter.selfadjointView<Eigen::Upper>();
+    EXX += threecenter.selfadjointView<Eigen::Upper>() * DMAT *
+           threecenter.selfadjointView<Eigen::Upper>();
   }
-  Eigen::MatrixXd EXXs =
-      std::accumulate(EXX_thread.begin(), EXX_thread.end(),
-                      Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()).eval());
-  double energy = CalculateEnergy(DMAT, EXXs);
-  return Mat_p_Energy(energy, EXXs);
+  double energy = CalculateEnergy(DMAT, EXX);
+  return Mat_p_Energy(energy, EXX);
 }
 
 Mat_p_Energy ERIs::CalculateEXX(const Eigen::MatrixXd& occMos,
                                 const Eigen::MatrixXd& DMAT) const {
 
-  std::vector<Eigen::MatrixXd> EXX_thread = std::vector<Eigen::MatrixXd>(
-      OPENMP::getMaxThreads(),
-      Eigen::MatrixXd::Zero(occMos.rows(), occMos.rows()));
+  Eigen::MatrixXd EXX = Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols());
 
-#pragma omp parallel for
+#pragma omp parallel for schedule(guided) reduction(+ : EXX)
   for (Index i = 0; i < _threecenter.size(); i++) {
     const Eigen::MatrixXd TCxMOs_T =
         occMos.transpose() *
         _threecenter[i].UpperMatrix().selfadjointView<Eigen::Upper>();
-    EXX_thread[OPENMP::getThreadId()] += TCxMOs_T.transpose() * TCxMOs_T;
+    EXX += TCxMOs_T.transpose() * TCxMOs_T;
   }
 
-  Eigen::MatrixXd EXXs =
-      2 * std::accumulate(
-              EXX_thread.begin(), EXX_thread.end(),
-              Eigen::MatrixXd::Zero(occMos.rows(), occMos.rows()).eval());
+  EXX *= 2;
 
-  double energy = CalculateEnergy(DMAT, EXXs);
-  return Mat_p_Energy(energy, EXXs);
+  double energy = CalculateEnergy(DMAT, EXX);
+  return Mat_p_Energy(energy, EXX);
 }
 
 Mat_p_Energy ERIs::CalculateERIs_4c_small_molecule(
@@ -152,16 +136,14 @@ Mat_p_Energy ERIs::CalculateERIs_4c_small_molecule(
 
 Mat_p_Energy ERIs::CalculateEXX_4c_small_molecule(
     const Eigen::MatrixXd& DMAT) const {
-  std::vector<Eigen::MatrixXd> EXX_thread = std::vector<Eigen::MatrixXd>(
-      OPENMP::getMaxThreads(), Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()));
+  Eigen::MatrixXd EXX = Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols());
 
   const Eigen::VectorXd& fourc_vector = _fourcenter.get_4c_vector();
 
   Index dftBasisSize = DMAT.rows();
   Index vectorSize = (dftBasisSize * (dftBasisSize + 1)) / 2;
-#pragma omp parallel for
+#pragma omp parallel for reduction(+ : EXX)
   for (Index i = 0; i < dftBasisSize; i++) {
-    Index thread = OPENMP::getThreadId();
     Index sum_i = (i * (i + 1)) / 2;
     for (Index j = i; j < dftBasisSize; j++) {
       Index index_ij = DMAT.cols() * i - sum_i + j;
@@ -186,25 +168,17 @@ Mat_p_Energy ERIs::CalculateEXX_4c_small_molecule(
             factorkl = 0.5;
           }
           double factor = factorij * factorkl;
-          EXX_thread[thread](i, l) +=
-              factor * DMAT(j, k) * fourc_vector(_index_ij_kl);
-          EXX_thread[thread](j, l) +=
-              factor * DMAT(i, k) * fourc_vector(_index_ij_kl);
-          EXX_thread[thread](i, k) +=
-              factor * DMAT(j, l) * fourc_vector(_index_ij_kl);
-          EXX_thread[thread](j, k) +=
-              factor * DMAT(i, l) * fourc_vector(_index_ij_kl);
+          EXX(i, l) += factor * DMAT(j, k) * fourc_vector(_index_ij_kl);
+          EXX(j, l) += factor * DMAT(i, k) * fourc_vector(_index_ij_kl);
+          EXX(i, k) += factor * DMAT(j, l) * fourc_vector(_index_ij_kl);
+          EXX(j, k) += factor * DMAT(i, l) * fourc_vector(_index_ij_kl);
         }
       }
     }
   }
 
-  Eigen::MatrixXd EXXs =
-      std::accumulate(EXX_thread.begin(), EXX_thread.end(),
-                      Eigen::MatrixXd::Zero(DMAT.rows(), DMAT.cols()).eval());
-
-  double energy = CalculateEnergy(DMAT, EXXs);
-  return Mat_p_Energy(energy, EXXs);
+  double energy = CalculateEnergy(DMAT, EXX);
+  return Mat_p_Energy(energy, EXX);
 }
 
 Mat_p_Energy ERIs::CalculateERIs_4c_direct(const AOBasis& dftbasis,

--- a/src/libxtp/gwbse/rpa.cc
+++ b/src/libxtp/gwbse/rpa.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -56,14 +56,15 @@ void RPA::UpdateRPAInputEnergies(const Eigen::VectorXd& dftenergies,
 template <bool imag>
 Eigen::MatrixXd RPA::calculate_epsilon(double frequency) const {
   const Index size = _Mmn.auxsize();
-  std::vector<Eigen::MatrixXd> thread_result = std::vector<Eigen::MatrixXd>(
-      OPENMP::getMaxThreads(), Eigen::MatrixXd::Zero(size, size));
+
+  Eigen::MatrixXd result = Eigen::MatrixXd::Identity(size, size);
+
   const Index lumo = _homo + 1;
   const Index n_occ = lumo - _rpamin;
   const Index n_unocc = _rpamax - lumo + 1;
   const double freq2 = frequency * frequency;
   const double eta2 = _eta * _eta;
-#pragma omp parallel for
+#pragma omp parallel for schedule(dynamic) reduction(+ : result)
   for (Index m_level = 0; m_level < n_occ; m_level++) {
     const double qp_energy_m = _energies(m_level);
 
@@ -80,13 +81,9 @@ Eigen::MatrixXd RPA::calculate_epsilon(double frequency) const {
       sum += deltEf / (deltEf.square() + eta2);
       denom = 2 * sum;
     }
-    thread_result[OPENMP::getThreadId()] +=
-        Mmn_RPA.transpose() * denom.asDiagonal() * Mmn_RPA;
+    result += Mmn_RPA.transpose() * denom.asDiagonal() * Mmn_RPA;
   }
-  Eigen::MatrixXd result = Eigen::MatrixXd::Identity(size, size);
-  for (const auto& mat : thread_result) {
-    result += mat;
-  }
+
   return result;
 }
 

--- a/src/libxtp/numerical_integration/density_integration.cc
+++ b/src/libxtp/numerical_integration/density_integration.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -69,17 +69,15 @@ template <class Grid>
 double DensityIntegration<Grid>::IntegrateDensity(
     const Eigen::MatrixXd& density_matrix) {
 
-  Index nthreads = OPENMP::getMaxThreads();
-  std::vector<double> N_thread = std::vector<double>(nthreads, 0.0);
+  double N = 0.0;
   SetupDensityContainer();
 
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(guided) reduction(+ : N)
   for (Index i = 0; i < _grid.getBoxesSize(); ++i) {
     const GridBox& box = _grid[i];
     if (!box.Matrixsize()) {
       continue;
     }
-    double N_box = 0.0;
     const Eigen::MatrixXd DMAT_here = box.ReadFromBigMatrix(density_matrix);
     const std::vector<Eigen::Vector3d>& points = box.getGridPoints();
     const std::vector<double>& weights = box.getGridWeights();
@@ -88,35 +86,27 @@ double DensityIntegration<Grid>::IntegrateDensity(
       Eigen::VectorXd ao = box.CalcAOValues(points[p]);
       double rho = (ao.transpose() * DMAT_here * ao)(0, 0) * weights[p];
       _densities[i][p] = rho;
-      N_box += rho;
+      N += rho;
     }
-    N_thread[OPENMP::getThreadId()] += N_box;
   }
-  double N = std::accumulate(N_thread.begin(), N_thread.end(), 0.0);
   return N;
 }
 
 template <class Grid>
 Gyrationtensor DensityIntegration<Grid>::IntegrateGyrationTensor(
     const Eigen::MatrixXd& density_matrix) {
-
-  Index nthreads = OPENMP::getMaxThreads();
-  std::vector<double> N_thread = std::vector<double>(nthreads, 0.0);
-  std::vector<Eigen::Vector3d> centroid_thread =
-      std::vector<Eigen::Vector3d>(nthreads, Eigen::Vector3d::Zero());
-  std::vector<Eigen::Matrix3d> gyration_thread =
-      std::vector<Eigen::Matrix3d>(nthreads, Eigen::Matrix3d::Zero());
+  double N = 0.0;
+  Eigen::Vector3d centroid = Eigen::Vector3d::Zero();
+  Eigen::Matrix3d gyration = Eigen::Matrix3d::Zero();
 
   SetupDensityContainer();
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(guided)reduction(+:N)reduction(+:centroid)reduction(+:gyration)
   for (Index i = 0; i < _grid.getBoxesSize(); ++i) {
     const GridBox& box = _grid[i];
     if (!box.Matrixsize()) {
       continue;
     }
-    double N_box = 0.0;
-    Eigen::Vector3d centroid_box = Eigen::Vector3d::Zero();
-    Eigen::Matrix3d gyration_box = Eigen::Matrix3d::Zero();
+
     const Eigen::MatrixXd DMAT_here = box.ReadFromBigMatrix(density_matrix);
     const std::vector<Eigen::Vector3d>& points = box.getGridPoints();
     const std::vector<double>& weights = box.getGridWeights();
@@ -125,21 +115,11 @@ Gyrationtensor DensityIntegration<Grid>::IntegrateGyrationTensor(
       Eigen::VectorXd ao = box.CalcAOValues(points[p]);
       double rho = (ao.transpose() * DMAT_here * ao).value() * weights[p];
       _densities[i][p] = rho;
-      N_box += rho;
-      centroid_box += rho * points[p];
-      gyration_box += rho * points[p] * points[p].transpose();
+      N += rho;
+      centroid += rho * points[p];
+      gyration += rho * points[p] * points[p].transpose();
     }
-    N_thread[OPENMP::getThreadId()] += N_box;
-    centroid_thread[OPENMP::getThreadId()] += centroid_box;
-    gyration_thread[OPENMP::getThreadId()] += gyration_box;
   }
-  double N = std::accumulate(N_thread.begin(), N_thread.end(), 0.0);
-  Eigen::Vector3d centroid =
-      std::accumulate(centroid_thread.begin(), centroid_thread.end(),
-                      Eigen::Vector3d::Zero().eval());
-  Eigen::Matrix3d gyration =
-      std::accumulate(gyration_thread.begin(), gyration_thread.end(),
-                      Eigen::Matrix3d::Zero().eval());
 
   // Normalize
   centroid = centroid / N;

--- a/src/libxtp/numerical_integration/vxc_potential.cc
+++ b/src/libxtp/numerical_integration/vxc_potential.cc
@@ -1,5 +1,5 @@
 /*
- *            Copyright 2009-2019 The VOTCA Development Team
+ *            Copyright 2009-2020 The VOTCA Development Team
  *                       (http://www.votca.org)
  *
  *      Licensed under the Apache License, Version 2.0 (the "License")
@@ -154,14 +154,9 @@ template <class Grid>
 Mat_p_Energy Vxc_Potential<Grid>::IntegrateVXC(
     const Eigen::MatrixXd& density_matrix) const {
 
-  Index nthreads = OPENMP::getMaxThreads();
+  Mat_p_Energy vxc = Mat_p_Energy(density_matrix.rows(), density_matrix.cols());
 
-  std::vector<Eigen::MatrixXd> vxc_thread = std::vector<Eigen::MatrixXd>(
-      nthreads,
-      Eigen::MatrixXd::Zero(density_matrix.rows(), density_matrix.cols()));
-  std::vector<double> Exc_thread = std::vector<double>(nthreads, 0.0);
-
-#pragma omp parallel for schedule(guided)
+#pragma omp parallel for schedule(guided) reduction(+ : vxc)
   for (Index i = 0; i < _grid.getBoxesSize(); ++i) {
     const GridBox& box = _grid[i];
     if (!box.Matrixsize()) {
@@ -197,18 +192,11 @@ Mat_p_Energy Vxc_Potential<Grid>::IntegrateVXC(
       auto addXC = weight * (0.5 * xc.df_drho * ao + 2.0 * xc.df_dsigma * grad);
       Vxc_here.noalias() += addXC * ao.transpose();
     }
-    box.AddtoBigMatrix(vxc_thread[OPENMP::getThreadId()], Vxc_here);
-    Exc_thread[OPENMP::getThreadId()] += EXC_box;
+    box.AddtoBigMatrix(vxc.matrix(), Vxc_here);
+    vxc.energy() += EXC_box;
   }
 
-  double EXC = std::accumulate(Exc_thread.begin(), Exc_thread.end(), 0.0);
-  Eigen::MatrixXd Vxc = std::accumulate(
-      vxc_thread.begin(), vxc_thread.end(),
-      Eigen::MatrixXd::Zero(density_matrix.rows(), density_matrix.cols())
-          .eval());
-
-  Mat_p_Energy Oxc(EXC, Vxc + Vxc.transpose());
-  return Oxc;
+  return Mat_p_Energy(vxc.energy(), vxc.matrix() + vxc.matrix().transpose());
 }
 
 template class Vxc_Potential<Vxc_Grid>;

--- a/src/tests/test_aopotential.cc
+++ b/src/tests/test_aopotential.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -179,7 +179,6 @@ BOOST_AUTO_TEST_CASE(aopotentials_test) {
   ECPAOBasis ecpbasis;
   ecpbasis.Fill(ecps, orbitals.QMAtoms());
   AOECP ecp;
-  OPENMP::setMaxThreads(1);
   ecp.FillPotential(aobasis, ecpbasis);
   Eigen::MatrixXd ecp_ref = Eigen::MatrixXd::Zero(17, 17);
   ecp_ref << 21.6188, 1.34835, 0, 0, 0, 2.29744, 0, 0, 0, 0.209711, 1.01592,
@@ -811,7 +810,6 @@ BOOST_AUTO_TEST_CASE(large_l_test) {
   ECPAOBasis ecpbasis;
   ecpbasis.Fill(ecps, mol);
   AOECP ecp;
-  OPENMP::setMaxThreads(1);
   ecp.FillPotential(dftbasis, ecpbasis);
 
   Eigen::MatrixXd ecp_ref = Eigen::MatrixXd::Zero(dftbasissize, dftbasissize);

--- a/src/tests/test_bse_operator.cc
+++ b/src/tests/test_bse_operator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -295,7 +295,6 @@ BOOST_AUTO_TEST_CASE(bse_operator) {
   opt.vmin = 0;
 
   orbitals.setBSEindices(0, 16);
-  OPENMP::setMaxThreads(1);
   HqpOperator Hqp_op(epsilon_inv, Mmn, Hqp);
   Hqp_op.configure(opt);
   Eigen::MatrixXd hqp_mat = Hqp_op.get_full_matrix();

--- a/src/tests/test_threecenter_dft.cc
+++ b/src/tests/test_threecenter_dft.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2009-2019 The VOTCA Development Team (http://www.votca.org)
+ * Copyright 2009-2020 The VOTCA Development Team (http://www.votca.org)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,6 @@ Eigen::MatrixXd ReadMatrixFromString(const std::string& matrix) {
 }
 
 BOOST_AUTO_TEST_CASE(small_basis) {
-
-  OPENMP::setMaxThreads(1);
 
   std::ofstream xyzfile("molecule.xyz");
   xyzfile << " 5" << std::endl;
@@ -261,7 +259,6 @@ BOOST_AUTO_TEST_CASE(small_basis) {
 }
 
 BOOST_AUTO_TEST_CASE(large_l_test) {
-  OPENMP::setMaxThreads(1);
   std::ofstream xyzfile("C2.xyz");
   xyzfile << " 2" << std::endl;
   xyzfile << " C2" << std::endl;


### PR DESCRIPTION
Openmp is now required in version 4.5

this is not a big problem for gcc and icc but clang is a bit stupid, so you have to have clang-10 to use it properly. This seems to be a bug in the clang package. 