### PR TITLE
openmp is deactivated for clang<10

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2.2.0
         with:
-          submodules: true
+          fetch-depth: 0
       - name: Run Votca Setup
         id: setup
         uses: votca/actions/setup@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ For more detailed information about the changes see the history of the
 * address missing includes (#452)
 * fix readjobfiles path (#453)
 * standardising include order and style in header files (#448)
-* changed to OpenMP reductions instead of hand crafted solutions (#466)
+* changed to OpenMP reductions instead of hand crafted solutions (#466, #471)
 * switch to GitHub Actions as CI (#467)
 
 ## Version 1.6.1 (released XX.04.20)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
-find_package(OpenMP 4.5)
-set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Used for thread parallelization in xtp")
-
+#openmp with clang smaller version 10 and user defined reductions is buggy https://bugs.llvm.org/show_bug.cgi?id=44134
+if ("${CMAKE_CXX_COMPILER_ID}"  NOT STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
+  find_package(OpenMP 4.5)
+  set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Used for thread parallelization in xtp")
+endif()
 
 ########################################################################
 # User input options                                                   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
 #openmp with clang smaller version 10 and user defined reductions is buggy https://bugs.llvm.org/show_bug.cgi?id=44134
-if (CMAKE_CXX_COMPILER_ID  NOT STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
   find_package(OpenMP 4.5)
   set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Used for thread parallelization in xtp")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
 #openmp with clang smaller version 10 and user defined reductions is buggy https://bugs.llvm.org/show_bug.cgi?id=44134
-if ("${CMAKE_CXX_COMPILER_ID}"  NOT STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
+if (CMAKE_CXX_COMPILER_ID  NOT STREQUAL "Clang" OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 10.0)
   find_package(OpenMP 4.5)
   set_package_properties(OpenMP PROPERTIES TYPE RECOMMENDED PURPOSE "Used for thread parallelization in xtp")
 endif()


### PR DESCRIPTION
Fixing https://github.com/votca/xtp/issues/469