### PR TITLE
remove special xml symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ For more detailed information about the changes see the history of the
 * add def2-tzvp, def2-tzvpp, def2-qzvp, def2-qzvpp for Rb,I,Ag,Xe (#480)
 * create a map between orca and libxc functional names (#461)
 * fix path to share/data (#486, #487)
+* remove special XML symbols (#488)
 
 ## Version 1.6.1 (released 21.06.20)
 * fix warnings on Ubuntu 20.04 (#438, #460)

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -39,7 +39,7 @@
             <dodavidson help="use davidson solver" default="true" choices="bool"/>
             <davidson_correction help="Davidson correction method" default="DPR" choices="DPR,OHLSEN"/>
             <davidson_tolerance help="Numerical tolerance" default="normal" choices="loose,normal,strict"/>
-            <davidson_ortho help="orthogonalisation routine: Gram&#x2013;Schmidt or QR" default="GS" choices="GS,QR"/>
+            <davidson_ortho help="orthogonalisation routine: GramSchmidt or QR" default="GS" choices="GS,QR"/>
             <davidson_update help=" how large the search space" default="safe" choices="min,safe,max"/>
             <davidson_maxiter help="max iterations" default="50" choices="int+"/>
             <domatrixfree help="solve without explicitly setting up BSE matrix, (slower but a lot less memory required" default="true" choices="bool">false</domatrixfree>

--- a/share/xtp/xml/iqm.xml
+++ b/share/xtp/xml/iqm.xml
@@ -34,7 +34,7 @@
           <dodavidson help="use davidson solver" default="true" choices="bool"/>
           <davidson_correction help="Davidson correction method" default="DPR" choices="DPR,OHLSEN"/>
           <davidson_tolerance help="Numerical tolerance" default="normal" choices="loose,normal,strict"/>
-          <davidson_ortho help="orthogonalisation routine: Gram&#x2013;Schmidt or QR" default="GS" choices="GS,QR"/>
+          <davidson_ortho help="orthogonalisation routine: GramSchmidt or QR" default="GS" choices="GS,QR"/>
           <davidson_update help=" how large the search space" default="safe" choices="min,safe,max"/>
           <davidson_maxiter help="max iterations" default="50" choices="int+"/>
           <domatrixfree help="solve without explicitly setting up BSE matrix, (slower but a lot less memory required" default="true" choices="bool">false</domatrixfree>


### PR DESCRIPTION
## The problem
XML use hexadecimals to represent some unicode symbols like `-` that is represented as `&#x2013;`.
These symbols are causing some translation problem when transforming the XML files into RST.

## The solution
Remove the special symbols.