### PR TITLE
added qp root output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,6 +46,7 @@ Version 1.7-dev
 -  add mkl builds to CI (#496)
 -  convert markdown to rst (#497)
 -  enable CXX only in CMake (#499)
+-  added verbose option for rootfinder (#503)
 
 Version 1.6.1 (released 21.06.20)
 =================================

--- a/src/libxtp/gwbse/gw.cc
+++ b/src/libxtp/gwbse/gw.cc
@@ -325,6 +325,7 @@ boost::optional<double> GW::SolveQP_Grid(double intercept0, double frequency0,
       double qp_weight = 1.0 / (1.0 - gradient);
       roots.push_back(std::make_pair(f, qp_weight));
       if (std::abs(gradient) < gradient_max) {
+        gradient_max = std::abs(gradient);
         qp_energy = f;
         pole_found = true;
       }

--- a/src/libxtp/gwbse/gw.cc
+++ b/src/libxtp/gwbse/gw.cc
@@ -306,6 +306,7 @@ boost::optional<double> GW::SolveQP_Linearisation(double intercept0,
 
 boost::optional<double> GW::SolveQP_Grid(double intercept0, double frequency0,
                                          Index gw_level) const {
+  std::vector<std::pair<double, double>> roots;
   const double range =
       _opt.qp_grid_spacing * double(_opt.qp_grid_steps - 1) / 2.0;
   boost::optional<double> newf = boost::none;
@@ -320,15 +321,33 @@ boost::optional<double> GW::SolveQP_Grid(double intercept0, double frequency0,
     double targ = fqp.value(freq);
     if (targ_prev * targ < 0.0) {  // Sign change
       double f = SolveQP_Bisection(freq_prev, targ_prev, freq, targ, fqp);
-      double gradient = std::abs(fqp.deriv(f));
-      if (gradient < gradient_max) {
+      double gradient = fqp.deriv(f);
+      double qp_weight = 1.0 / (1.0 - gradient);
+      roots.push_back(std::make_pair(f, qp_weight));
+      if (std::abs(gradient) < gradient_max) {
         qp_energy = f;
-        gradient_max = gradient;
         pole_found = true;
       }
     }
     freq_prev = freq;
     targ_prev = targ;
+  }
+  if (Log::current_level > Log::error) {
+#pragma omp critical
+    {
+      if (!pole_found) {
+        XTP_LOG(Log::info, _log)
+            << " No roots found for qplevel:" << gw_level << std::flush;
+      } else {
+        XTP_LOG(Log::info, _log) << " Roots found for qplevel:" << gw_level
+                                 << " (qpenergy:qpweight)\n\t\t";
+        for (auto& root : roots) {
+          XTP_LOG(Log::info, _log) << std::setprecision(5) << root.first << ":"
+                                   << root.second << " ";
+        }
+        XTP_LOG(Log::info, _log) << "Root chosen " << qp_energy << std::flush;
+      }
+    }
   }
 
   if (pole_found) {


### PR DESCRIPTION
implements https://github.com/votca/xtp/issues/492

due to the parallelization, it is not guaranteed that the output is ordered by level index, but the index->qp_weight,qp_energy is always correctly output. 