### PR TITLE
remove constant from neighborlist defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,8 @@ Version 2021-dev
 -  add NOSCF option for iqm in internal and external DFT (#483)
 -  added versions to output files (#523)
 -  write an empty state file if it does not exist yet (#526)
-   
+-  fix double unit conversion (#531)
+
 Version 1.6.2 (released XX.07.20)
 =================================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -48,6 +48,7 @@ Version 1.7-dev
 -  enable CXX only in CMake (#499)
 -  implement RPA correlation energy (#498)
 -  added verbose option for rootfinder (#503)
+-  remove constant cutoff from neighborlist (#508)
 
 Version 1.6.1 (released 21.06.20)
 =================================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,7 @@ Version 1.7-dev
 -  added verbose option for rootfinder (#503)
 -  fix orca pointcharges (#504)
 -  remove constant cutoff from neighborlist (#508)
+-  fix default and flags properties issue (#511)
 
 Version 1.6.1 (released 21.06.20)
 =================================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,7 +50,7 @@ Version 1.7-dev
 -  implement RPA correlation energy (#498)
 -  added verbose option for rootfinder (#503)
 -  fix orca pointcharges (#504)
--  remove constant cutoff from neighborlist (#508)
+-  remove constant cutoff from neighborlist (#508, #509)
 -  fix default and flags properties issue (#511)
 -  add more checks to the dft_parse_part (#510)
 -  add NOSCF option for iqm in internal and external DFT (#483)

--- a/include/votca/xtp/settings.h
+++ b/include/votca/xtp/settings.h
@@ -146,16 +146,19 @@ class Settings {
       "ecp",                    // string
       "executable",             // string
       // "external_charge",        // Eigen::Vector9d
-      "functional",     // string
-      "name",           // string
-      "optimize",       // boolean
-      "orca",           // string
-      "polarization",   // boolean
-      "read_guess",     // boolean
-      "spin",           // index
-      "scratch",        // string
-      "write_charges",  // boolean
-      "xtpdft",         // string
+      "functional",       // string
+      "name",             // string
+      "optimize",         // boolean
+      "orca",             // string
+      "polarization",     // boolean
+      "read_guess",       // boolean
+      "spin",             // index
+      "scratch",          // string
+      "use_auxbasisset",  // boolean
+      "use_ecp",          // boolean
+      "write_charges",    // boolean
+      "xtpdft"            // string
+
   };
 
   std::vector<std::string> _mandatory_keyword = {

--- a/share/xtp/data/qmpackage_defaults.xml
+++ b/share/xtp/data/qmpackage_defaults.xml
@@ -4,7 +4,9 @@
   <charge help="Molecular charge" default="0" choices="int">0</charge>
   <spin help="Molecular multiplicity" default="1" choices="int+">1</spin>
   <basisset help="Basis set for MOs" default="def2-tzvp">def2-tzvp</basisset>
+  <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
   <auxbasisset help="Auxiliary basis set for RI" default="aux-def2-tzvp">aux-def2-tzvp</auxbasisset>
+  <use_ecp help="use an Effective Core Potentials for DFT Calculations" default="false" choices="bool"/>
   <optimize help="Perform a molecular geometry optimization" default="false" choices="bool">false</optimize>
   <functional default="XC_HYB_GGA_XC_PBEH">XC_HYB_GGA_XC_PBEH</functional>
   <scratch help="path to the scratch folder" default="/tmp/qmpackage">/tmp/qmpackage</scratch>
@@ -19,6 +21,8 @@
   </orca>
   <xtpdft>
     <with_screening help="screening" default="true" choices="bool">true</with_screening>
+    <use_external_field help="whether or not to use an external field" default="false" choices="bool"/>
+    <use_external_density help="whether or not to use a precomputed external density" default="false" choices="bool"/>
     <screening_eps help="screening eps" default="1e-9" choices="float+">1e-9</screening_eps>
     <four_center_method help="method to compute the four-center integrals" default="cache" choices="cache,direct,RI">RI</four_center_method>
     <convergence>

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -9,6 +9,7 @@
     <dftpackage>
       <package>
         <name help="Name of the DFT package" default="xtp" choices="xtp,orca">xtp</name>
+        <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
       </package>
     </dftpackage>
     <use_mpsfile help="check for MPS file with external multipoles for embedding" default="false" choices="bool"/>

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -14,7 +14,7 @@
     <use_mpsfile help="check for MPS file with external multipoles for embedding" default="false" choices="bool"/>
     <mpsfile help="MPS file to read from if use_mpsfile"/>
     <use_guess help="Use a precomputed wave function" default="false" choices="bool"/>
-    <guess help="File to read the wave function if the use guess flag is set to true">
+    <guess help="File to read the wave function if the use guess flag is set to true"/>
     <gwbse_engine>
       <tasks help="task to compute" default="input,dft,parse,gwbse" choices="[input,dft,parse,gwbse]"/>
       <gwbse_options>

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -11,6 +11,10 @@
         <name help="Name of the DFT package" default="xtp" choices="xtp,orca">xtp</name>
       </package>
     </dftpackage>
+    <use_mpsfile help="check for MPS file with external multipoles for embedding" default="false" choices="bool"/>
+    <mpsfile help="MPS file to read from if use_mpsfile"/>
+    <use_guess help="Use a precomputed wave function" default="false" choices="bool"/>
+    <guess help="File to read the wave function if the use guess flag is set to true">
     <gwbse_engine>
       <tasks help="task to compute" default="input,dft,parse,gwbse" choices="[input,dft,parse,gwbse]"/>
       <gwbse_options>

--- a/share/xtp/xml/eanalyze.xml
+++ b/share/xtp/xml/eanalyze.xml
@@ -5,6 +5,9 @@
     <resolution_pairs help="Bin size for pair energy histogram" unit="eV" default="0.01" choices="float+"/>
     <resolution_spatial help="Bin size for site energy correlation" unit="eV" default="0.01" choices="float+"/>
     <states help="states to analyze" default="e, h, s, t" choices="[e,h,s,t]"/>
-    <energy_landscape help="" default="false" choices="bool"/>
+    <do_energy_landscape help="enable the computation of the energy landscape" default="false" choices="bool"/>
+    <do_distance_mode help="enable the distance mode"/>
+    <match_pattern help="Regex use to search for the segments" default="*"/>
+    <distancemode help="mode to use if do_distance_mode is set to true" default="centerofmass" choices="atoms,centerofmass"/>
   </eanalyze>
 </options>

--- a/share/xtp/xml/eqm.xml
+++ b/share/xtp/xml/eqm.xml
@@ -58,6 +58,7 @@
     <dftpackage>
       <package>
         <name help="Name of the DFT package" default="xtp" choices="xtp,orca"/>
+        <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
       </package>
     </dftpackage>
     <esp_options help="xml file with options for CHELPG calculations">

--- a/share/xtp/xml/ianalyze.xml
+++ b/share/xtp/xml/ianalyze.xml
@@ -4,5 +4,8 @@
     <resolution_logJ2 help="Bin size of histogram log(J2)" default="0.5" choices="float+"/>
     <resolution_space help="Bin size for r in log(J2(r))" unit="nm" default="0.05" choices="float+"/>
     <states help="states to analyze" default="e, h, s, t" choices="[e,h,s,t]"/>
+    <do_pairtype default="false" choices="bool"/>
+    <pairtype help="method to compute the pairtype" choices="Hopping,Excitoncl"/>
+    <do_resolution_spatial default="false" choices="bool"/>
   </ianalyze>
 </options>

--- a/share/xtp/xml/ianalyze.xml
+++ b/share/xtp/xml/ianalyze.xml
@@ -5,7 +5,7 @@
     <resolution_space help="Bin size for r in log(J2(r))" unit="nm" default="0.05" choices="float+"/>
     <states help="states to analyze" default="e, h, s, t" choices="[e,h,s,t]"/>
     <do_pairtype default="false" choices="bool"/>
-    <pairtype help="method to compute the pairtype" choices="Hopping,Excitoncl"/>
+    <pairtype help="method to compute the pairtype" default="Hopping" choices="Hopping,Excitoncl"/>
     <do_resolution_spatial default="false" choices="bool"/>
   </ianalyze>
 </options>

--- a/share/xtp/xml/iexcitoncl.xml
+++ b/share/xtp/xml/iexcitoncl.xml
@@ -3,6 +3,6 @@
   <iexcitoncl help="Classical coupling of transition charges" section="sec:iexcitoncl">
     <map_file help="xml file with segment definition" default="votca_map.xml"/>
     <job_file help="name of jobfile to which jobs are written" default="exciton.jobs"/>
-    <use_state help="Use pair of segments and exciton labels" default="false" choices="bool"/>
+    <use_states help="Use pair of segments and exciton labels" default="false" choices="bool"/>
   </iexcitoncl>
 </options>

--- a/share/xtp/xml/iexcitoncl.xml
+++ b/share/xtp/xml/iexcitoncl.xml
@@ -3,5 +3,6 @@
   <iexcitoncl help="Classical coupling of transition charges" section="sec:iexcitoncl">
     <map_file help="xml file with segment definition" default="votca_map.xml"/>
     <job_file help="name of jobfile to which jobs are written" default="exciton.jobs"/>
+    <use_state help="Use pair of segments and exciton labels" default="false" choices="bool"/>
   </iexcitoncl>
 </options>

--- a/share/xtp/xml/iqm.xml
+++ b/share/xtp/xml/iqm.xml
@@ -79,6 +79,7 @@
       <package>
         <name help="Name of the DFT package" default="xtp" choices="orca,xtp"/>
         <read_guess help="Read wave function guess" default="true" choices="bool"/>
+        <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
       </package>
     </dftpackage>
   </iqm>

--- a/share/xtp/xml/molpol.xml
+++ b/share/xtp/xml/molpol.xml
@@ -7,8 +7,8 @@
       <max_iter help="Maximum number of iterations" default="500"/>
       <exp_damp help="Thole sharpness parameter" default="0.39"/>
     </options_polar>
-    <mode help="Read the polar target from a file or a qmpackage logfile" choices="target,qmpackage"/>
-    <target help="should have this format: pxx pxy pxz pyy pyz pzz"/>
+    <mode help="Read the polar target from a file or a qmpackage logfile" choices="file,qmpackage"/>
+    <target_polarisability help="should have this format: pxx pxy pxz pyy pyz pzz"/>
     <qmpackage help="qmpackage name if mode is qmpackage" default="orca" choices="orca"/>
     <logfile help="logfile of DFTpackage to read Target polarisability from if mode is qmpackage" default="system.log"/>
     <tolerance help="convergence tolerance" default="1e-4" choices="float+"/>

--- a/share/xtp/xml/molpol.xml
+++ b/share/xtp/xml/molpol.xml
@@ -7,8 +7,10 @@
       <max_iter help="Maximum number of iterations" default="500"/>
       <exp_damp help="Thole sharpness parameter" default="0.39"/>
     </options_polar>
-    <qmpackage help="DFT package polarization calculation was run with" default="orca" choices="orca"/>
-    <logfile help="logfile of DFTpackage to read Target polarisability from" default="votca.orb"/>
+    <mode help="Read the polar target from a file or a qmpackage logfile" choices="target,qmpackage"/>
+    <target help="should have this format: pxx pxy pxz pyy pyz pzz"/>
+    <qmpackage help="qmpackage name if mode is qmpackage" default="orca" choices="orca"/>
+    <logfile help="logfile of DFTpackage to read Target polarisability from if mode is qmpackage" default="votca.orb"/>
     <tolerance help="convergence tolerance" default="1e-4" choices="float+"/>
     <iterations help="maximum number of iterations" default="100" choices="int+"/>
   </molpol>

--- a/share/xtp/xml/molpol.xml
+++ b/share/xtp/xml/molpol.xml
@@ -10,7 +10,7 @@
     <mode help="Read the polar target from a file or a qmpackage logfile" choices="target,qmpackage"/>
     <target help="should have this format: pxx pxy pxz pyy pyz pzz"/>
     <qmpackage help="qmpackage name if mode is qmpackage" default="orca" choices="orca"/>
-    <logfile help="logfile of DFTpackage to read Target polarisability from if mode is qmpackage" default="votca.orb"/>
+    <logfile help="logfile of DFTpackage to read Target polarisability from if mode is qmpackage" default="system.log"/>
     <tolerance help="convergence tolerance" default="1e-4" choices="float+"/>
     <iterations help="maximum number of iterations" default="100" choices="int+"/>
   </molpol>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <options>
   <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
-    <type help="segments names if the segmentname method is used"/>
+    <segmentname help="segments names if the segmentname method is used"/>
     <cutoff help="cutoff value if the segmentname method is used" unit="nm"/>
     <cutoff_type help="method to define the cutoff" default="constant" choices="constant,segmentname"/>
     <constant help="cutoff for all other types of pairs if the constant method is used" unit="nm" default="1.5" choices="float+"/>
     <use_exciton_cutoff help="Use exciton cutoff" default="false" choices="bool"/>
-    <exciton_cutoff help="value" units="nm"/>
+    <exciton_cutoff help="cutoff for classical exciton transition charge treatment" units="nm"/>
   </neighborlist>
 </options>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <options>
   <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
+  <type help="segments names if the segmentname method is used"/>
+  <cutoff help="cutoff value if the segmentname method is used" unit="nm"/>
+  <cutoff_type help="method to define the cutoff" default="constant" choices="constant,segmentname"/>
+  <constant help="cutoff for all other types of pairs if the constant method is used" unit="nm" default="1.5" choices="float+"/>
+  <use_exciton_cutoff help="Use exciton cutoff" default="false" choices="bool"/>
+  <exciton_cutoff help="value" units="nm">
   </neighborlist>
 </options>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <options>
   <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
-    <constant help="cutoff for all other types of pairs" unit="nm" default="1.5" choices="float+"/>
   </neighborlist>
 </options>

--- a/share/xtp/xml/neighborlist.xml
+++ b/share/xtp/xml/neighborlist.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <options>
   <neighborlist help="Determines neighbouring pairs for exciton transport" section="sec:neighborlist">
-  <type help="segments names if the segmentname method is used"/>
-  <cutoff help="cutoff value if the segmentname method is used" unit="nm"/>
-  <cutoff_type help="method to define the cutoff" default="constant" choices="constant,segmentname"/>
-  <constant help="cutoff for all other types of pairs if the constant method is used" unit="nm" default="1.5" choices="float+"/>
-  <use_exciton_cutoff help="Use exciton cutoff" default="false" choices="bool"/>
-  <exciton_cutoff help="value" units="nm">
+    <type help="segments names if the segmentname method is used"/>
+    <cutoff help="cutoff value if the segmentname method is used" unit="nm"/>
+    <cutoff_type help="method to define the cutoff" default="constant" choices="constant,segmentname"/>
+    <constant help="cutoff for all other types of pairs if the constant method is used" unit="nm" default="1.5" choices="float+"/>
+    <use_exciton_cutoff help="Use exciton cutoff" default="false" choices="bool"/>
+    <exciton_cutoff help="value" units="nm"/>
   </neighborlist>
 </options>

--- a/src/libxtp/calculators/eanalyze.cc
+++ b/src/libxtp/calculators/eanalyze.cc
@@ -29,12 +29,7 @@ void EAnalyze::Initialize(const tools::Property &user_options) {
   _resolution_pairs = options.get(".resolution_pairs").as<double>();
   _resolution_sites = options.get(".resolution_sites").as<double>();
   _resolution_spatial = options.get(".resolution_spatial").as<double>();
-
-  if (options.exists(".pattern")) {
-    _seg_pattern = options.get(".pattern").as<std::string>();
-  } else {
-    _seg_pattern = "*";
-  }
+  _seg_pattern = options.get(".match_pattern").as<std::string>();
 
   std::string statestrings = options.get(".states").as<std::string>();
   tools::Tokenizer tok(statestrings, ",\n\t ");
@@ -44,13 +39,10 @@ void EAnalyze::Initialize(const tools::Property &user_options) {
     _states.push_back(QMStateType(state));
   }
 
-  _doenergy_landscape = options.get(".energy_landscape").as<bool>();
+  _doenergy_landscape = options.get(".do_energy_landscape").as<bool>();
 
-  if (options.exists(".distancemode")) {
-    std::vector<std::string> choices = {"atoms", "centerofmass"};
-    std::string distancemode =
-        options.ifExistsAndinListReturnElseThrowRuntimeError<std::string>(
-            ".distancemode", choices);
+  if (options.(".do_distance_mode")) {
+    std::string distancemode = options.get("distancemode").as<std::string>();
     if (distancemode == "centerofmass") {
       _atomdistances = false;
     } else {

--- a/src/libxtp/calculators/eanalyze.cc
+++ b/src/libxtp/calculators/eanalyze.cc
@@ -41,7 +41,7 @@ void EAnalyze::Initialize(const tools::Property &user_options) {
 
   _doenergy_landscape = options.get(".do_energy_landscape").as<bool>();
 
-  if (options.(".do_distance_mode")) {
+  if (options.get(".do_distance_mode").as<bool>()) {
     std::string distancemode = options.get("distancemode").as<std::string>();
     if (distancemode == "centerofmass") {
       _atomdistances = false;

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -45,7 +45,7 @@ void IAnalyze::Initialize(const tools::Property &user_options) {
   }
 
   _resolution_logJ2 = options.get(".resolution_logJ2").as<double>();
-  if (options.get(".pairtype").as<bool>()) {
+  if (options.get(".do_pairtype").as<bool>()) {
     _do_pairtype = true;
     std::string _store_stdstring = options.get(".pairtype").as<std::string>();
     if (_store_stdstring.find("Hopping") != std::string::npos) {

--- a/src/libxtp/calculators/ianalyze.cc
+++ b/src/libxtp/calculators/ianalyze.cc
@@ -45,7 +45,7 @@ void IAnalyze::Initialize(const tools::Property &user_options) {
   }
 
   _resolution_logJ2 = options.get(".resolution_logJ2").as<double>();
-  if (options.exists(".pairtype")) {
+  if (options.get(".pairtype").as<bool>()) {
     _do_pairtype = true;
     std::string _store_stdstring = options.get(".pairtype").as<std::string>();
     if (_store_stdstring.find("Hopping") != std::string::npos) {
@@ -59,7 +59,7 @@ void IAnalyze::Initialize(const tools::Property &user_options) {
       _do_pairtype = false;
     }
   }
-  if (options.exists(".resolution_spatial")) {
+  if (options.get(".do_resolution_spatial").as<bool>()) {
     _resolution_spatial = options.get(".resolution_spatial").as<double>();
     if (_resolution_spatial != 0.0) {
       _do_IRdependence = true;

--- a/src/libxtp/calculators/neighborlist.cc
+++ b/src/libxtp/calculators/neighborlist.cc
@@ -45,8 +45,8 @@ void Neighborlist::Initialize(const tools::Property& user_options) {
           "ERROR: Faulty pair definition for cut-off's: Need two segment names "
           "separated by a space");
     }
-    _cutoffs[names[0]][names[1]] = cutoff * tools::conv::nm2bohr;
-    _cutoffs[names[1]][names[0]] = cutoff * tools::conv::nm2bohr;
+    _cutoffs[names[0]][names[1]] = cutoff;
+    _cutoffs[names[1]][names[0]] = cutoff;
     if (std::find(_included_segments.begin(), _included_segments.end(),
                   names[0]) == _included_segments.end()) {
       _included_segments.push_back(names[0]);
@@ -160,8 +160,8 @@ bool Neighborlist::EvaluateFrame(Topology& top) {
       if (cutoff > 0.5 * min) {
         throw std::runtime_error(
             (boost::format("Cutoff is larger than half the box size. Maximum "
-                           "allowed cutoff is %1$1.1f") %
-             (tools::conv::nm2bohr * 0.5 * min))
+                           "allowed cutoff is %1$1.1f (nm)") %
+             (tools::conv::bohr2nm * 0.5 * min))
                 .str());
       }
       double cutoff2 = cutoff * cutoff;

--- a/src/libxtp/calculators/neighborlist.cc
+++ b/src/libxtp/calculators/neighborlist.cc
@@ -57,14 +57,15 @@ void Neighborlist::Initialize(const tools::Property& user_options) {
     }
   }
 
-  if (options.exists(".constant")) {
+  const std::string& cutoff_type = options.get("cutoff_type").as<std::string>();
+  if (cutoff_type == "constant") {
     _useConstantCutoff = true;
     _constantCutoff =
         options.get(".constant").as<double>() * tools::conv::nm2bohr;
   } else {
     _useConstantCutoff = false;
   }
-  if (options.exists(".exciton_cutoff")) {
+  if (options.get(".use_exciton_cutoff").as<bool>()) {
     _useExcitonCutoff = true;
     _excitonqmCutoff =
         options.get(".exciton_cutoff").as<double>() * tools::conv::nm2bohr;

--- a/src/libxtp/calculators/neighborlist.cc
+++ b/src/libxtp/calculators/neighborlist.cc
@@ -33,7 +33,7 @@ void Neighborlist::Initialize(const tools::Property& user_options) {
   std::vector<tools::Property*> segs = options.Select(".segments");
 
   for (tools::Property* segprop : segs) {
-    std::string types = segprop->get("type").as<std::string>();
+    std::string types = segprop->get("segmentname").as<std::string>();
     double cutoff = segprop->get("cutoff").as<double>() * tools::conv::nm2bohr;
 
     tools::Tokenizer tok(types, " ");

--- a/src/libxtp/dftengine/dftengine.cc
+++ b/src/libxtp/dftengine/dftengine.cc
@@ -56,7 +56,7 @@ void DFTEngine::Initialize(Property& options) {
   const string key_xtpdft = "package.xtpdft";
   _dftbasis_name = options.get(key + ".basisset").as<string>();
 
-  if (options.exists(key + ".auxbasisset")) {
+  if (options.get(key + ".use_auxbasisset").as<bool>()) {
     _auxbasis_name = options.get(key + ".auxbasisset").as<string>();
   }
 
@@ -68,7 +68,7 @@ void DFTEngine::Initialize(Property& options) {
     _screening_eps = options.get(key_xtpdft + ".screening_eps").as<double>();
   }
 
-  if (options.exists(key + ".ecp")) {
+  if (options.get(key + ".use_ecp").as<bool>()) {
     _ecp_name = options.get(key + ".ecp").as<string>();
     _with_ecp = true;
   } else {
@@ -80,7 +80,7 @@ void DFTEngine::Initialize(Property& options) {
   _grid_name = options.get(key_xtpdft + ".integration_grid").as<string>();
   _xc_functional_name = options.get(key + ".functional").as<string>();
 
-  if (options.exists(key_xtpdft + ".externaldensity")) {
+  if (options.get(key_xtpdft + ".use_external_density").as<bool>()) {
     _integrate_ext_density = true;
     _orbfilename = options.ifExistsReturnElseThrowRuntimeError<string>(
         key_xtpdft + ".externaldensity.orbfile");
@@ -90,47 +90,44 @@ void DFTEngine::Initialize(Property& options) {
         key_xtpdft + ".externaldensity.state");
   }
 
-  if (options.exists(key_xtpdft + ".externalfield")) {
+  if (options.get(key_xtpdft + ".use_external_field").as<bool>()) {
     _integrate_ext_field = true;
 
     _extfield = options.ifExistsReturnElseThrowRuntimeError<Eigen::Vector3d>(
         key_xtpdft + ".externalfield");
   }
 
-  if (options.exists(key_xtpdft + ".convergence")) {
-    _conv_opt.Econverged =
-        options.get(key_xtpdft + ".convergence.energy").as<double>();
-    _conv_opt.error_converged =
-        options.get(key_xtpdft + ".convergence.error").as<double>();
-    _max_iter =
-        options.get(key_xtpdft + ".convergence.max_iterations").as<Index>();
+  _conv_opt.Econverged =
+      options.get(key_xtpdft + ".convergence.energy").as<double>();
+  _conv_opt.error_converged =
+      options.get(key_xtpdft + ".convergence.error").as<double>();
+  _max_iter =
+      options.get(key_xtpdft + ".convergence.max_iterations").as<Index>();
 
-    string method =
-        options.get(key_xtpdft + ".convergence.method").as<string>();
-    if (method == "DIIS") {
-      _conv_opt.usediis = true;
-    } else if (method == "mixing") {
-      _conv_opt.usediis = false;
-    }
-    if (!_conv_opt.usediis) {
-      _conv_opt.histlength = 1;
-      _conv_opt.maxout = false;
-    }
-    _conv_opt.mixingparameter =
-        options.get(key_xtpdft + ".convergence.mixing").as<double>();
-    _conv_opt.levelshift =
-        options.get(key_xtpdft + ".convergence.levelshift").as<double>();
-    _conv_opt.levelshiftend =
-        options.get(key_xtpdft + ".convergence.levelshift_end").as<double>();
-    _conv_opt.maxout =
-        options.get(key_xtpdft + ".convergence.DIIS_maxout").as<bool>();
-    _conv_opt.histlength =
-        options.get(key_xtpdft + ".convergence.DIIS_length").as<Index>();
-    _conv_opt.diis_start =
-        options.get(key_xtpdft + ".convergence.DIIS_start").as<double>();
-    _conv_opt.adiis_start =
-        options.get(key_xtpdft + ".convergence.ADIIS_start").as<double>();
+  string method = options.get(key_xtpdft + ".convergence.method").as<string>();
+  if (method == "DIIS") {
+    _conv_opt.usediis = true;
+  } else if (method == "mixing") {
+    _conv_opt.usediis = false;
   }
+  if (!_conv_opt.usediis) {
+    _conv_opt.histlength = 1;
+    _conv_opt.maxout = false;
+  }
+  _conv_opt.mixingparameter =
+      options.get(key_xtpdft + ".convergence.mixing").as<double>();
+  _conv_opt.levelshift =
+      options.get(key_xtpdft + ".convergence.levelshift").as<double>();
+  _conv_opt.levelshiftend =
+      options.get(key_xtpdft + ".convergence.levelshift_end").as<double>();
+  _conv_opt.maxout =
+      options.get(key_xtpdft + ".convergence.DIIS_maxout").as<bool>();
+  _conv_opt.histlength =
+      options.get(key_xtpdft + ".convergence.DIIS_length").as<Index>();
+  _conv_opt.diis_start =
+      options.get(key_xtpdft + ".convergence.DIIS_start").as<double>();
+  _conv_opt.adiis_start =
+      options.get(key_xtpdft + ".convergence.ADIIS_start").as<double>();
 
   return;
 }

--- a/src/libxtp/gwbse/gwbse.cc
+++ b/src/libxtp/gwbse/gwbse.cc
@@ -202,40 +202,36 @@ void GWBSE::Initialize(tools::Property& options) {
   }
 
   // eigensolver options
-  if (options.exists(key + ".eigensolver")) {
-    _bseopt.davidson = options.get(key + ".eigensolver.dodavidson").as<bool>();
+  _bseopt.davidson = options.get(key + ".eigensolver.dodavidson").as<bool>();
 
-    if (_bseopt.davidson) {
+  if (_bseopt.davidson) {
 
-      _bseopt.matrixfree =
-          options.get(key + ".eigensolver.domatrixfree").as<bool>();
+    _bseopt.matrixfree =
+        options.get(key + ".eigensolver.domatrixfree").as<bool>();
 
-      _bseopt.davidson_correction =
-          options.get(key + ".eigensolver.davidson_correction")
-              .as<std::string>();
+    _bseopt.davidson_correction =
+        options.get(key + ".eigensolver.davidson_correction").as<std::string>();
 
-      _bseopt.davidson_ortho =
-          options.get(key + ".eigensolver.davidson_ortho").as<std::string>();
+    _bseopt.davidson_ortho =
+        options.get(key + ".eigensolver.davidson_ortho").as<std::string>();
 
-      _bseopt.davidson_tolerance =
-          options.get(key + ".eigensolver.davidson_tolerance")
-              .as<std::string>();
+    _bseopt.davidson_tolerance =
+        options.get(key + ".eigensolver.davidson_tolerance").as<std::string>();
 
-      _bseopt.davidson_update =
-          options.get(key + ".eigensolver.davidson_update").as<std::string>();
+    _bseopt.davidson_update =
+        options.get(key + ".eigensolver.davidson_update").as<std::string>();
 
-      _bseopt.davidson_maxiter =
-          options.get(key + ".eigensolver.davidson_maxiter").as<Index>();
+    _bseopt.davidson_maxiter =
+        options.get(key + ".eigensolver.davidson_maxiter").as<Index>();
 
-      // check size
-      if (_bseopt.nmax > bse_size / 4) {
-        XTP_LOG(Log::error, *_pLog)
-            << TimeStamp()
-            << " Warning : Too many eigenvalues required for Davidson. Default "
-               "to Lapack diagonalization"
-            << flush;
-        _bseopt.davidson = false;
-      }
+    // check size
+    if (_bseopt.nmax > bse_size / 4) {
+      XTP_LOG(Log::error, *_pLog)
+          << TimeStamp()
+          << " Warning : Too many eigenvalues required for Davidson. Default "
+             "to Lapack diagonalization"
+          << flush;
+      _bseopt.davidson = false;
     }
   }
 
@@ -257,10 +253,8 @@ void GWBSE::Initialize(tools::Property& options) {
         << " BSE with Hqp offdiagonal elements" << flush;
   }
 
-  if (options.exists(key + ".vxc")) {
-    _functional = options.get(key + ".vxc.functional").as<std::string>();
-    _grid = options.get(key + ".vxc.grid").as<std::string>();
-  }
+  _functional = options.get(key + ".vxc.functional").as<std::string>();
+  _grid = options.get(key + ".vxc.grid").as<std::string>();
 
   _auxbasis_name = options.get(key + ".auxbasisset").as<std::string>();
   _dftbasis_name = options.get(key + ".basisset").as<std::string>();

--- a/src/libxtp/jobcalculators/iexcitoncl.cc
+++ b/src/libxtp/jobcalculators/iexcitoncl.cc
@@ -49,7 +49,7 @@ void IEXCITON::Initialize(const tools::Property& user_options) {
       LoadDefaultsAndUpdateWithUserOptions("xtp", user_options);
   ParseCommonOptions(options);
 
-  if (options.exists(".states")) {
+  if (options.get(".use_states").as<bool>()) {
     std::string parse_string = options.get(".states").as<std::string>();
     _statemap = FillParseMaps(parse_string);
   }

--- a/src/libxtp/tools/dftgwbse.cc
+++ b/src/libxtp/tools/dftgwbse.cc
@@ -76,19 +76,15 @@ void DftGwBse::Initialize(const tools::Property& user_options) {
   // XML OUTPUT
   _xml_output = _job_name + "_summary.xml";
 
-  // checking for additional requests
-  _do_external = false;
-  _do_guess = false;
-
   // check for MPS file with external multipoles for embedding
-  if (options.exists(".mpsfile")) {
-    _do_external = true;
+  _do_external = options.get("use_mpsfile").as<bool>();
+  if (_do_external) {
     _mpsfile = options.get(".mpsfile").as<std::string>();
   }
 
   // check if guess is requested
-  if (options.exists(".guess")) {
-    _do_guess = true;
+  _do_guess = options.get("use_guess").as<bool>();
+  if (_do_guess) {
     _guess_file = options.get(".guess").as<std::string>();
   }
 

--- a/src/libxtp/tools/molpol.cc
+++ b/src/libxtp/tools/molpol.cc
@@ -44,20 +44,10 @@ void MolPol::Initialize(const tools::Property& user_options) {
       ".mpsoutput", _job_name + "_polar.mps");
   _polar_options = options.get(".options_polar");
 
-  bool target_exists = options.exists(".target");
-  bool qmpackage_exists = options.exists(".qmpackage");
-  if (target_exists && qmpackage_exists) {
-    throw std::runtime_error(
-        "Can only read either from target or qmpackage logfile");
-  }
+  // polar targer or qmpackage logfile
+  const std::string& mode = options.get("mode").as<std::string>();
 
-  if (!target_exists && !qmpackage_exists) {
-    throw std::runtime_error(
-        "You have to define a polar targer <target> or a or qmpackage logfile");
-  }
-
-  if (target_exists) {
-
+  if (mode == "target") {
     Eigen::VectorXd target_vec = options.get(".target").as<Eigen::VectorXd>();
     if (target_vec.size() != 6) {
       throw std::runtime_error(

--- a/src/libxtp/tools/molpol.cc
+++ b/src/libxtp/tools/molpol.cc
@@ -47,8 +47,9 @@ void MolPol::Initialize(const tools::Property& user_options) {
   // polar targer or qmpackage logfile
   const std::string& mode = options.get("mode").as<std::string>();
 
-  if (mode == "target") {
-    Eigen::VectorXd target_vec = options.get(".target").as<Eigen::VectorXd>();
+  if (mode == "file") {
+    Eigen::VectorXd target_vec =
+        options.get(".target_polarisability").as<Eigen::VectorXd>();
     if (target_vec.size() != 6) {
       throw std::runtime_error(
           "ERROR <options.molpol.target> "

--- a/src/tests/test_dftengine.cc
+++ b/src/tests/test_dftengine.cc
@@ -124,8 +124,12 @@ BOOST_AUTO_TEST_CASE(dft_full) {
   xml << "<charge>0</charge>" << std::endl;
   xml << "<functional>XC_HYB_GGA_XC_PBEH</functional>" << std::endl;
   xml << "<basisset>3-21G.xml</basisset>" << std::endl;
+  xml << "<use_auxbasisset>false</use_auxbasisset>" << std::endl;
+  xml << "<use_ecp>false</use_ecp>" << std::endl;
   xml << "<read_guess>0</read_guess>" << std::endl;
   xml << "<xtpdft>" << std::endl;
+  xml << "<use_external_field>false</use_external_field>" << std::endl;
+  xml << "<use_external_density>false</use_external_density>" << std::endl;
   xml << "<with_screening choices=\"bool\">true</with_screening>\n";
   xml << "<screening_eps  choices=\"float+\">1e-9</screening_eps>\n";
   xml << "<four_center_method>cache</four_center_method>\n";
@@ -245,8 +249,12 @@ BOOST_AUTO_TEST_CASE(density_guess) {
   xml << "<charge>0</charge>" << std::endl;
   xml << "<functional>XC_HYB_GGA_XC_PBEH</functional>" << std::endl;
   xml << "<basisset>3-21G.xml</basisset>" << std::endl;
+  xml << "<use_auxbasisset>false</use_auxbasisset>" << std::endl;
+  xml << "<use_ecp>false</use_ecp>" << std::endl;
   xml << "<read_guess>0</read_guess>" << std::endl;
   xml << "<xtpdft>" << std::endl;
+  xml << "<use_external_field>false</use_external_field>" << std::endl;
+  xml << "<use_external_density>false</use_external_density>" << std::endl;
   xml << "<with_screening choices=\"bool\">true</with_screening>\n";
   xml << "<screening_eps  choices=\"float+\">1e-9</screening_eps>\n";
   xml << "<four_center_method>cache</four_center_method>\n";


### PR DESCRIPTION
## problem
see issue #508 

## proposed solution
Remove the `constant` keyword from the defaults of the `neighborlist` calculator.