### PR TITLE
GHA: create release workflow on stable

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,28 @@
+name: Make Release
+on:
+  push:
+    tags:
+    - 'v[1-9]*'
+
+jobs:
+  release:
+    name: Make Release
+    if: github.repository_owner == 'votca'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Changlog
+        uses: votca/actions/release_changelog@master
+        with:
+          version: ${{ github.ref }}
+          changelog: 'release_changelog.md'
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.VOTCA_BOT_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          prerelease: ${{ contains(github.ref, 'rc') }}
+          body_path: 'release_changelog.md'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ For more detailed information about the changes see the history of the
 [repository](https://github.com/votca/xtp/commits/master).
 
 ## Version 1.6.2 (released XX.07.20)
-* move CI to GitHub Actions (#512, #514, #516)
+* move CI to GitHub Actions (#512, #514, #516, #519)
 
 ## Version 1.6.1 (released 21.06.20)
 * fix warnings on Ubuntu 20.04 (#438, #460)


### PR DESCRIPTION
Same as #518, but we seem to need this on `stable` as well for the `v1.6.2` release.