### PR TITLE
added versions to files and made the lock for stateserver better

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -51,6 +51,7 @@ Version 1.7-dev
 -  added verbose option for rootfinder (#503)
 -  fix orca pointcharges (#504)
 -  add more checks to the dft_parse_part (#510)
+-  added versions to output files (#523)
 
 Version 1.6.2 (released XX.07.20)
 =================================

--- a/include/votca/xtp/jobtopology.h
+++ b/include/votca/xtp/jobtopology.h
@@ -106,6 +106,8 @@ class JobTopology {
   Logger& _log;
   std::vector<std::unique_ptr<Region> > _regions;
   std::string _workdir = "";
+
+  static constexpr int jobtopology_version() { return 1; }
 };
 }  // namespace xtp
 }  // namespace votca

--- a/include/votca/xtp/orbitals.h
+++ b/include/votca/xtp/orbitals.h
@@ -395,6 +395,8 @@ class Orbitals {
   tools::EigenSystem _BSE_triplet;
 
   bool _use_Hqp_offdiag = true;
+
+  static constexpr int orbitals_version() { return 1; }
 };
 
 }  // namespace xtp

--- a/include/votca/xtp/topology.h
+++ b/include/votca/xtp/topology.h
@@ -88,7 +88,7 @@ class Topology {
   std::vector<const Segment *> FindAllSegmentsOnMolecule(
       const Segment &seg1, const Segment &seg2) const;
 
- protected:
+ private:
   std::vector<Segment> _segments;
 
   std::unique_ptr<csg::BoundaryCondition> _bc = nullptr;
@@ -99,6 +99,8 @@ class Topology {
 
   csg::BoundaryCondition::eBoxtype AutoDetectBoxType(
       const Eigen::Matrix3d &box);
+
+  static constexpr int topology_version() { return 1; }
 };
 
 }  // namespace xtp

--- a/src/libxtp/jobtopology.cc
+++ b/src/libxtp/jobtopology.cc
@@ -27,6 +27,7 @@
 #include "votca/xtp/qmregion.h"
 #include "votca/xtp/segmentmapper.h"
 #include "votca/xtp/staticregion.h"
+#include "votca/xtp/version.h"
 
 namespace votca {
 namespace xtp {
@@ -338,7 +339,8 @@ void JobTopology::WriteToHdf5(std::string filename) const {
   CheckpointFile cpf(filename, CheckpointAccessLevel::CREATE);
   CheckpointWriter a = cpf.getWriter();
   a(_job.getId(), "jobid");
-
+  a(XtpVersionStr(), "XTPVersion");
+  a(jobtopology_version(), "version");
   for (const auto& region : _regions) {
     CheckpointWriter w =
         cpf.getWriter("region_" + std::to_string(region->getId()));

--- a/src/libxtp/orbitals.cc
+++ b/src/libxtp/orbitals.cc
@@ -505,7 +505,8 @@ void Orbitals::WriteToCpt(CheckpointFile f) const {
 }
 
 void Orbitals::WriteToCpt(CheckpointWriter w) const {
-  w(XtpVersionStr(), "Version");
+  w(XtpVersionStr(), "XTPVersion");
+  w(orbitals_version(), "version");
   w(_basis_set_size, "basis_set_size");
   w(_occupied_levels, "occupied_levels");
   w(_number_alpha_electrons, "number_alpha_electrons");

--- a/src/libxtp/topology.cc
+++ b/src/libxtp/topology.cc
@@ -29,6 +29,7 @@
 #include "votca/xtp/checkpointwriter.h"
 #include "votca/xtp/segment.h"
 #include "votca/xtp/topology.h"
+#include "votca/xtp/version.h"
 
 namespace votca {
 namespace xtp {
@@ -180,6 +181,8 @@ void Topology::WriteToPdb(std::string filename) const {
 }
 
 void Topology::WriteToCpt(CheckpointWriter &w) const {
+  w(XtpVersionStr(), "XTPVersion");
+  w(topology_version(), "version");
   w(_time, "time");
   w(_step, "step");
   w(this->getBox(), "box");


### PR DESCRIPTION
Introduced version numbers for qmmm checkpoint, orbital files and topology files. 

This allows to later introduce backwards compatible changes. 
uses `int` because they can be equality compared.
