### PR TITLE
fix single/multiline keywords in Orca

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,7 @@ Version 2021-dev
 -  fix build with clang-11 (#546)
 -  Add a molden parser to xtp (#547)
 -  Correct self-energy frequency derivative (#550)
+-  fix multiline orca keyword ($552)
 
 Version 1.6.2 *SuperGitta* (released 22.08.20)
 =================================

--- a/src/libxtp/qmpackages/orca.cc
+++ b/src/libxtp/qmpackages/orca.cc
@@ -272,7 +272,7 @@ bool Orca::WriteInputFile(const Orbitals& orbitals) {
   for (const auto& prop : this->_settings.property("orca")) {
     const std::string& prop_name = prop.name();
     if (prop_name == "pointcharges") {
-      _options += this->CreateInputSection("orca.pointcharges", true);
+      _options += this->CreateInputSection("orca.pointcharges");
     } else if (prop_name != "method") {
       _options += this->CreateInputSection("orca." + prop_name);
     }
@@ -803,13 +803,12 @@ std::string Orca::indent(const double& number) {
   return snumber;
 }
 
-std::string Orca::CreateInputSection(const std::string& key,
-                                     bool single_line) const {
+std::string Orca::CreateInputSection(const std::string& key) const {
   std::stringstream stream;
   std::string section = key.substr(key.find(".") + 1);
   stream << "%" << section;
-  if (single_line) {
-    stream << " " << _settings.get(key) << "\n";
+  if (KeywordIsSingleLine(key)) {
+    stream << " " << this->_settings.get(key) << "\n";
   } else {
     stream << "\n"
            << this->_settings.get(key) << "\n"
@@ -817,6 +816,13 @@ std::string Orca::CreateInputSection(const std::string& key,
   }
 
   return stream.str();
+}
+
+bool Orca::KeywordIsSingleLine(const std::string& key) const {
+  tools::Tokenizer values(this->_settings.get(key), " ");
+  std::vector<std::string> words;
+  values.ToVector(words);
+  return ((words.size() <= 1) ? true : false);
 }
 
 std::string Orca::WriteMethod() const {

--- a/src/libxtp/qmpackages/orca.h
+++ b/src/libxtp/qmpackages/orca.h
@@ -98,8 +98,8 @@ class Orca : public QMPackage {
   void GetCoordinates(T& mol, std::string& line,
                       std::ifstream& input_file) const;
   std::string WriteMethod() const;
-  std::string CreateInputSection(const std::string& key,
-                                 bool single_line = false) const;
+  std::string CreateInputSection(const std::string& key) const;
+  bool KeywordIsSingleLine(const std::string& key) const;
   std::string GetOrcaFunctionalName() const;
 
   std::unordered_map<std::string, std::string> _convergence_map{

--- a/src/tests/test_orca.cc
+++ b/src/tests/test_orca.cc
@@ -226,6 +226,7 @@ BOOST_AUTO_TEST_CASE(input_generation_version_4_0_1) {
            << "<orca>\n"
            << "<method></method>\n"
            << "<scf>GUESS PMODEL</scf>\n"
+           << "<maxcore>3000</maxcore>\n"
            << "</orca>\n"
            << "</package>";
   defaults.close();
@@ -261,7 +262,7 @@ BOOST_AUTO_TEST_CASE(input_generation_version_4_0_1) {
   BOOST_CHECK_EQUAL(inp.substr(index1, index2 - index1),
                     "%basis\nGTOName =\"system.bas\";\n");
 
-  // check basis section
+  // check scf section multiline
   index1 = inp.find("%scf");
   index2 = inp.find("end", index1);
   BOOST_CHECK_EQUAL(inp.substr(index1, index2 - index1),
@@ -270,6 +271,12 @@ BOOST_AUTO_TEST_CASE(input_generation_version_4_0_1) {
   // Check method
   index1 = inp.find("!");
   BOOST_CHECK_EQUAL(inp.substr(index1), "! DFT pbe0   \n");
+
+  // Check singleline orca kewords
+  index1 = inp.find("%maxcore");
+  index2 = inp.find("\n", index1);
+  std::cout << "\ninp: " << inp.substr(index1) << "\n";
+  BOOST_CHECK_EQUAL(inp.substr(index1, index2 - index1), "%maxcore 3000");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## The problem
see #552 

## Solution 
Check whether the Orca keyword is single or multi-line and print it accordingly