### PR TITLE
AddContainer updates ID

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,7 @@ Version 2021-dev
 -  fix QMMM with QP (#590, #591)
 -  fix bug in setCenter of AODipole (#593)
 -  extra check in orca unit test (#594)
+-  fixed atomid numbering while adding containers (#599)
 
 Version 1.6.3 (released XX.08.20)
 =================================

--- a/include/votca/xtp/atomcontainer.h
+++ b/include/votca/xtp/atomcontainer.h
@@ -72,7 +72,7 @@ class AtomContainer {
   void AddContainer(const AtomContainer<T>& container) {
     Index offset = _atomlist.size();
     _type += "_" + container._type;
-    for (auto at : container._atomlist) {
+    for (const auto& at : container._atomlist) {
       T atom(at.getId() + offset, at.getElement(), at.getPos());
       _atomlist.push_back(atom);
     }

--- a/include/votca/xtp/atomcontainer.h
+++ b/include/votca/xtp/atomcontainer.h
@@ -70,16 +70,6 @@ class AtomContainer {
     calcPos();
   }
 
-  void AddContainer(const AtomContainer<QMAtom>& container) {
-    Index offset = _atomlist.size();
-    _type += "_" + container._type;
-    for (const auto& at : container._atomlist) {
-      QMAtom atom(at.getId() + offset, at.getElement(), at.getPos());
-      _atomlist.push_back(atom);
-    }
-    calcPos();
-  }
-
   const T& at(Index index) const { return _atomlist.at(index); }
   T& at(Index index) { return _atomlist.at(index); }
 

--- a/include/votca/xtp/atomcontainer.h
+++ b/include/votca/xtp/atomcontainer.h
@@ -70,9 +70,12 @@ class AtomContainer {
   }
 
   void AddContainer(const AtomContainer<T>& container) {
+    Index offset = _atomlist.size();
     _type += "_" + container._type;
-    _atomlist.insert(_atomlist.end(), container._atomlist.begin(),
-                     container._atomlist.end());
+    for (auto at : container._atomlist) {
+      T atom(at.getId() + offset, at.getElement(), at.getPos());
+      _atomlist.push_back(atom);
+    }
     calcPos();
   }
 

--- a/include/votca/xtp/atomcontainer.h
+++ b/include/votca/xtp/atomcontainer.h
@@ -26,6 +26,7 @@
 #include <typeinfo>
 
 // VOTCA includes
+#include "qmatom.h"
 #include <votca/tools/elements.h>
 
 // Local VOTCA includes
@@ -69,11 +70,11 @@ class AtomContainer {
     calcPos();
   }
 
-  void AddContainer(const AtomContainer<T>& container) {
+  void AddContainer(const AtomContainer<QMAtom>& container) {
     Index offset = _atomlist.size();
     _type += "_" + container._type;
     for (const auto& at : container._atomlist) {
-      T atom(at.getId() + offset, at.getElement(), at.getPos());
+      QMAtom atom(at.getId() + offset, at.getElement(), at.getPos());
       _atomlist.push_back(atom);
     }
     calcPos();

--- a/include/votca/xtp/atomcontainer.h
+++ b/include/votca/xtp/atomcontainer.h
@@ -26,7 +26,6 @@
 #include <typeinfo>
 
 // VOTCA includes
-#include "qmatom.h"
 #include <votca/tools/elements.h>
 
 // Local VOTCA includes

--- a/include/votca/xtp/qmmolecule.h
+++ b/include/votca/xtp/qmmolecule.h
@@ -37,6 +37,17 @@ class QMMolecule : public AtomContainer<QMAtom> {
 
   void WriteXYZ(std::string filename, std::string header) const;
 
+  void AddContainer(const AtomContainer<QMAtom>& container) {
+    Index offset = _atomlist.size();
+    _type += "_" + container.getType();
+    for (const auto& at : container) {
+      // Update atom IDs to make sure they are unique
+      QMAtom atom(at.getId() + offset, at.getElement(), at.getPos());
+      _atomlist.push_back(atom);
+    }
+    calcPos();
+  }
+
   friend std::ostream& operator<<(std::ostream& out,
                                   const QMMolecule& container) {
     out << container.getId() << " " << container.getType() << "\n";

--- a/src/libxtp/gwbse/gwbse.cc
+++ b/src/libxtp/gwbse/gwbse.cc
@@ -594,13 +594,14 @@ bool GWBSE::Evaluate() {
   XTP_LOG(Log::error, *_pLog)
       << TimeStamp() << " Molecule Coordinates [A] " << flush;
   for (QMAtom& atom : _orbitals.QMAtoms()) {
-    std::string output =
-        (boost::format("  %1$s"
-                       "   %2$+1.4f %3$+1.4f %4$+1.4f") %
-         atom.getElement() % (atom.getPos().x() * tools::conv::bohr2ang) %
-         (atom.getPos().y() * tools::conv::bohr2ang) %
-         (atom.getPos().z() * tools::conv::bohr2ang))
-            .str();
+    std::string output = (boost::format("%5d"
+                                        "%5s"
+                                        "   %1.4f %1.4f %1.4f") %
+                          atom.getId() % atom.getElement() %
+                          (atom.getPos().x() * tools::conv::bohr2ang) %
+                          (atom.getPos().y() * tools::conv::bohr2ang) %
+                          (atom.getPos().z() * tools::conv::bohr2ang))
+                             .str();
 
     XTP_LOG(Log::error, *_pLog) << output << flush;
   }


### PR DESCRIPTION
fixes #597 

Or at least so I think, there are two assumptions:
- That it is fine to make a copy of the incoming atoms
- That the ID's of incoming molecules always start from zero

@JensWehner are these valid assumptions?