### PR TITLE
Update dipoledipoleinteraction.h

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Version 2022-dev
 -  fix lxml detection in cmake (#670)
 -  extend fchk writer with option to print single KS state densities and densities relative to the ground state (#662)
 -  added a more general constructor to cudamatrix (#671)
+-  changed reference to a copy (#676)
 
 
 Version 2021-rc.2 (released XX.01.21)

--- a/include/votca/xtp/dipoledipoleinteraction.h
+++ b/include/votca/xtp/dipoledipoleinteraction.h
@@ -104,7 +104,7 @@ class DipoleDipoleInteraction
   }
 
   // this is not a fast method
-  const double& operator()(const Index i, const Index j) const {
+  double operator()(const Index i, const Index j) const {
     Index seg1id = Index(i / 3);
     Index xyz1 = Index(i % 3);
     Index seg2id = Index(j / 3);


### PR DESCRIPTION
Depending on the archtecture we could return a dangling reference although in practice this is typically a copy.