### PR TITLE
Add option for ext. field to xtp and orca

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ Version 2022-dev
 -  count the number of available CPUs for autogen_mapping script (#688)
 -  fixed issue with molden file path and orca executable path (#692)
 -  Fixed bug in mapping (#690)
+-  added support for external fields in DFT (#698)
 
 Version 2021.1 (released XX.03.21)
 ==================================

--- a/include/votca/xtp/settings.h
+++ b/include/votca/xtp/settings.h
@@ -146,20 +146,20 @@ class Settings {
       "ecp",                    // string
       "executable",             // string
       // "external_charge",        // Eigen::Vector9d
-      "functional",       // string
-      "name",             // string
-      "optimize",         // boolean
-      "orca",             // string
-      "polarization",     // boolean
-      "read_guess",       // boolean
-      "spin",             // index
-      "scratch",          // string
-      "use_auxbasisset",  // boolean
-      "use_ecp",          // boolean
-      "write_charges",    // boolean
-      "xtpdft",            // string
-      "use_external_field", // boolean
-      "externalfield"     //Eigen::Vector3d
+      "functional",          // string
+      "name",                // string
+      "optimize",            // boolean
+      "orca",                // string
+      "polarization",        // boolean
+      "read_guess",          // boolean
+      "spin",                // index
+      "scratch",             // string
+      "use_auxbasisset",     // boolean
+      "use_ecp",             // boolean
+      "write_charges",       // boolean
+      "xtpdft",              // string
+      "use_external_field",  // boolean
+      "externalfield"        // Eigen::Vector3d
 
   };
 

--- a/include/votca/xtp/settings.h
+++ b/include/votca/xtp/settings.h
@@ -157,7 +157,9 @@ class Settings {
       "use_auxbasisset",  // boolean
       "use_ecp",          // boolean
       "write_charges",    // boolean
-      "xtpdft"            // string
+      "xtpdft",            // string
+      "use_external_field", // boolean
+      "externalfield"     //Eigen::Vector3d
 
   };
 

--- a/share/xtp/data/qmpackage_defaults.xml
+++ b/share/xtp/data/qmpackage_defaults.xml
@@ -6,6 +6,8 @@
   <basisset help="Basis set for MOs" default="def2-tzvp">def2-tzvp</basisset>
   <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
   <auxbasisset help="Auxiliary basis set for RI" default="aux-def2-tzvp">aux-def2-tzvp</auxbasisset>
+  <use_external_field help="whether or not to use an external field in the dft calculation" default="false" choices="bool"/>
+  <externalfield help="Field in atomic units used if the use ext. field flag is true" default="0.0 0.0 0.0"/>
   <use_ecp help="use an Effective Core Potentials for DFT Calculations" default="false" choices="bool"/>
   <optimize help="Perform a molecular geometry optimization" default="false" choices="bool">false</optimize>
   <functional default="XC_HYB_GGA_XC_PBEH">XC_HYB_GGA_XC_PBEH</functional>
@@ -15,13 +17,12 @@
   <read_guess help="Read wave function guess" default="false" choices="bool">false</read_guess>
   <write_charges help="Print atomic charges" default="false" choices="bool">false</write_charges>
   <convergence_tightness help="" default="tight" choices="low,normal,tight,verytight">tight</convergence_tightness>
-  <cleanup help="files to remove after the calculation is done"> </cleanup>
+  <cleanup help="files to remove after the calculation is done"></cleanup>
   <orca>
     <method help="This is automatically fill with the functional and basis set"/>
   </orca>
   <xtpdft>
     <with_screening help="screening" default="true" choices="bool">true</with_screening>
-    <use_external_field help="whether or not to use an external field" default="false" choices="bool"/>
     <use_external_density help="whether or not to use a precomputed external density" default="false" choices="bool"/>
     <screening_eps help="screening eps" default="1e-9" choices="float+">1e-9</screening_eps>
     <four_center_method help="method to compute the four-center integrals" default="cache" choices="cache,direct,RI">RI</four_center_method>

--- a/share/xtp/xml/dftgwbse.xml
+++ b/share/xtp/xml/dftgwbse.xml
@@ -10,6 +10,8 @@
       <package>
         <name help="Name of the DFT package" default="xtp" choices="xtp,orca">xtp</name>
         <use_auxbasisset help="use an auxiliar basisset" default="true" choices="bool"/>
+        <use_external_field help="whether or not to use an external field in the dft calculation" default="false" choices="bool"/>
+        <externalfield help="Field in atomic units used if the use external field flag is true" default="0.0 0.0 0.0"/>
       </package>
     </dftpackage>
     <use_mpsfile help="check for MPS file with external multipoles for embedding" default="false" choices="bool"/>

--- a/src/libxtp/dftengine/dftengine.cc
+++ b/src/libxtp/dftengine/dftengine.cc
@@ -83,11 +83,11 @@ void DFTEngine::Initialize(Property& options) {
         key_xtpdft + ".externaldensity.state");
   }
 
-  if (options.get(key_xtpdft + ".use_external_field").as<bool>()) {
+  if (options.get(key + ".use_external_field").as<bool>()) {
     _integrate_ext_field = true;
 
     _extfield = options.ifExistsReturnElseThrowRuntimeError<Eigen::Vector3d>(
-        key_xtpdft + ".externalfield");
+        key + ".externalfield");
   }
 
   _conv_opt.Econverged =

--- a/src/libxtp/qmpackages/orca.cc
+++ b/src/libxtp/qmpackages/orca.cc
@@ -271,6 +271,28 @@ bool Orca::WriteInputFile(const Orbitals& orbitals) {
     WriteBackgroundCharges();
   }
 
+  // External Electric field
+  if (_settings.has_key("use_external_field")) {
+    if (_settings.get("use_external_field") == "true") {
+      if (_settings.has_key("externalfield")) {
+        tools::Tokenizer values(this->_settings.get("externalfield"), " ");
+        std::vector<std::string> field;
+        values.ToVector(field);
+        if(field.size() != 3){
+          throw std::runtime_error("Electric field does not have 3 values.");
+        }
+        inp_file << "%scf\n ";
+        inp_file << "  efield " << field[0] << ", " << field[1] << ", " << field[2] << "\n";
+        inp_file << "end\n";
+        inp_file << std::endl;
+      } else {
+        throw std::runtime_error(
+            "\nRequested a calculation with an external field, but no field is "
+            "specified.\n");
+      }
+    }
+  }
+
   // Write Orca section specified by the user
   for (const auto& prop : this->_settings.property("orca")) {
     const std::string& prop_name = prop.name();

--- a/src/libxtp/qmpackages/orca.cc
+++ b/src/libxtp/qmpackages/orca.cc
@@ -278,11 +278,12 @@ bool Orca::WriteInputFile(const Orbitals& orbitals) {
         tools::Tokenizer values(this->_settings.get("externalfield"), " ");
         std::vector<std::string> field;
         values.ToVector(field);
-        if(field.size() != 3){
+        if (field.size() != 3) {
           throw std::runtime_error("Electric field does not have 3 values.");
         }
         inp_file << "%scf\n ";
-        inp_file << "  efield " << field[0] << ", " << field[1] << ", " << field[2] << "\n";
+        inp_file << "  efield " << field[0] << ", " << field[1] << ", "
+                 << field[2] << "\n";
         inp_file << "end\n";
         inp_file << std::endl;
       } else {

--- a/src/tests/test_dftengine.cc
+++ b/src/tests/test_dftengine.cc
@@ -129,8 +129,8 @@ BOOST_AUTO_TEST_CASE(dft_full) {
   xml << "<use_auxbasisset>false</use_auxbasisset>" << std::endl;
   xml << "<use_ecp>false</use_ecp>" << std::endl;
   xml << "<read_guess>0</read_guess>" << std::endl;
-  xml << "<xtpdft>" << std::endl;
   xml << "<use_external_field>false</use_external_field>" << std::endl;
+  xml << "<xtpdft>" << std::endl;
   xml << "<use_external_density>false</use_external_density>" << std::endl;
   xml << "<with_screening choices=\"bool\">true</with_screening>\n";
   xml << "<screening_eps  choices=\"float+\">1e-9</screening_eps>\n";
@@ -227,10 +227,10 @@ BOOST_AUTO_TEST_CASE(density_guess) {
   xml << "<functional>XC_HYB_GGA_XC_PBEH</functional>" << std::endl;
   xml << "<basisset>3-21G.xml</basisset>" << std::endl;
   xml << "<use_auxbasisset>false</use_auxbasisset>" << std::endl;
+  xml << "<use_external_field>false</use_external_field>" << std::endl;
   xml << "<use_ecp>false</use_ecp>" << std::endl;
   xml << "<read_guess>0</read_guess>" << std::endl;
   xml << "<xtpdft>" << std::endl;
-  xml << "<use_external_field>false</use_external_field>" << std::endl;
   xml << "<use_external_density>false</use_external_density>" << std::endl;
   xml << "<with_screening choices=\"bool\">true</with_screening>\n";
   xml << "<screening_eps  choices=\"float+\">1e-9</screening_eps>\n";


### PR DESCRIPTION
I am trying to make the numerical polarizability calculator part of PyVotca. But I ran into problems with the options, setting an external field was very hard, because it is hidden now in the `qmpackage_defaults.xml`. What I did here is two things

1. I made the external field options part of the general package (within `dftgwbse.xml`) instead of only the xtp package
2. I added the option to print the external field to the orca input file, so one can also do calculations with an external field using orca.

My main concern with this pull request is that I understand the options handling to poorly and that there is possibly a better way of achieving the same thing. So have a critical look and let me know what you think.

