### PR TITLE
reworked commandline access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,7 @@ Version 2022-dev
 -  add command line option for number of gpus (#711)
 -  reworked iqm statefile reading (#712)
 -  made membervariable format consistent (#713)
+-  reworked commandline options (#715)
 
 Version 2021.1 (released XX.03.21)
 ==================================

--- a/src/libxtp/stateapplication.cc
+++ b/src/libxtp/stateapplication.cc
@@ -47,14 +47,11 @@ void StateApplication::AddCommandLineOptions() {
 
 void StateApplication::EvaluateSpecificOptions() {
   CheckRequired("file", "Please provide the state file");
-  CheckRequired("options",
-                "Please provide an xml file with calculator options");
   CheckOptions();
 }
 
 void StateApplication::execute() {
 
-  options_.LoadFromXML(OptionsMap()["options"].as<std::string>());
   Index nframes = OptionsMap()["nframes"].as<Index>();
   Index fframe = OptionsMap()["first-frame"].as<Index>();
   bool save = OptionsMap()["save"].as<bool>();

--- a/src/libxtp/tools/dftgwbse.cc
+++ b/src/libxtp/tools/dftgwbse.cc
@@ -68,7 +68,7 @@ void DftGwBse::ParseOptions(const tools::Property& options) {
   archive_file_ = job_name_ + ".orb";
 
   // XML OUTPUT
-  xml_output_ = job_name_ + " summary_.xml";
+  xml_output_ = job_name_ + "_summary.xml";
 
   // check for MPS file with external multipoles for embedding
   do_external_ = options.get("use_mpsfile").as<bool>();

--- a/src/libxtp/xtpapplication.cc
+++ b/src/libxtp/xtpapplication.cc
@@ -21,10 +21,13 @@
 #include <boost/format.hpp>
 
 // VOTCA includes
+#include <stdexcept>
 #include <votca/tools/globals.h>
 #include <votca/tools/propertyiomanipulator.h>
 
 // Local VOTCA includes
+#include "votca/tools/property.h"
+#include "votca/tools/tokenizer.h"
 #include "votca/xtp/openmp_cuda.h"
 #include "votca/xtp/version.h"
 #include "votca/xtp/xtpapplication.h"
@@ -61,6 +64,15 @@ void XtpApplication::Initialize(void) {
       "description,d", propt::value<std::string>(),
       std::string("Short description of a " + CalculatorType() + "s").c_str());
 
+  AddProgramOptions()(
+      "cmdoptions,c", propt::value<std::vector<std::string>>()->multitoken(),
+      "Modify options via command line by e.g. '-c xmltag.subtag=value'. "
+      "Use whitespace to separate multiple options");
+
+  AddProgramOptions()(
+      "printoptions,p", propt::value<std::string>(),
+      std::string("Prints xml options of a " + CalculatorType()).c_str());
+
 #ifdef USE_CUDA
   AddProgramOptions()("gpus,g", propt::value<Index>()->default_value(-1),
                       "  Number of gpus to use");
@@ -84,37 +96,65 @@ bool XtpApplication::EvaluateOptions() {
 #endif
 
   if (OptionsMap().count("description")) {
-    CheckRequired("description", "no " + CalculatorType() + " is given");
-    tools::Tokenizer tok(OptionsMap()["description"].as<std::string>(),
-                         " ,\n\t");
-    for (const std::string& n : tok) {
-      if (CalcExists(n)) {
-        PrintDescription(std::cout, n, "xtp/xml", Application::HelpLong);
-      } else {
-        std::cout << CalculatorType() << " " << n << " does not exist\n";
-      }
+    std::string calcname = OptionsMap()["description"].as<std::string>();
+    if (CalcExists(calcname)) {
+      PrintDescription(std::cout, calcname, "xtp/xml", Application::HelpLong);
+    } else {
+      std::cout << CalculatorType() << " " << calcname << " does not exist\n";
     }
+
     StopExecution();
     return true;
   }
-  CheckRequired("execute", "Nothing to do here: Abort.");
+  if (OptionsMap().count("printoptions")) {
+    std::string calcname = OptionsMap()["printoptions"].as<std::string>();
+    if (CalcExists(calcname)) {
+      tools::Property opt;
+      std::cout << "XML options for " << calcname << std::endl;
+      opt.LoadFromXML(tools::GetVotcaShare() + "/xtp/xml/" + calcname + ".xml");
+      std::cout << opt.get("options") << std::endl;
+    } else {
+      std::cout << CalculatorType() << " " << calcname << " does not exist\n";
+    }
 
-  tools::Tokenizer calcs(OptionsMap()["execute"].as<std::string>(), " ,\n\t");
-  std::vector<std::string> calc_string = calcs.ToVector();
-  if (calc_string.size() != 1) {
-    throw std::runtime_error("You can only run one " + CalculatorType() +
-                             " at the same time.");
+    StopExecution();
+    return true;
   }
 
-  if (CalcExists(calc_string[0])) {
-    CreateCalculator(calc_string[0]);
+  CheckRequired("execute", "Nothing to do here: Abort.");
+  std::string calcname = OptionsMap()["execute"].as<std::string>();
+
+  if (CalcExists(calcname)) {
+    CreateCalculator(calcname);
   } else {
-    std::cout << CalculatorType() << " " << calc_string[0]
-              << " does not exist\n";
+    std::cout << CalculatorType() << " " << calcname << " does not exist\n";
     StopExecution();
   }
 
   EvaluateSpecificOptions();
+
+  if (OptionsMap().count("options")) {
+    std::string optionsFile = OptionsMap()["options"].as<std::string>();
+    options_.LoadFromXML(optionsFile);
+  } else {
+    // Empty user options
+    tools::Property& opts = options_.add("options", "");
+    opts.add(calcname, "");
+  }
+
+  if (OptionsMap().count("cmdoptions")) {
+    for (const std::string& opt :
+         OptionsMap()["cmdoptions"].as<std::vector<std::string>>()) {
+      std::vector<std::string> entries = tools::Tokenizer(opt, "=").ToVector();
+      if (entries.size() != 2) {
+        throw std::runtime_error(opt + " is not well formated!");
+      } else {
+        options_.getOradd("options." + calcname + "." + entries[0]).value() =
+            entries[1];
+      }
+    }
+    std::cout << options_ << std::endl;
+  }
 
   return true;
 }

--- a/src/libxtp/xtpapplication.cc
+++ b/src/libxtp/xtpapplication.cc
@@ -153,7 +153,6 @@ bool XtpApplication::EvaluateOptions() {
             entries[1];
       }
     }
-    std::cout << options_ << std::endl;
   }
 
   return true;

--- a/src/tools/xtp_tools.cc
+++ b/src/tools/xtp_tools.cc
@@ -59,31 +59,11 @@ class XtpTools final : public xtp::XtpApplication {
 void XtpTools::CreateCalculator(const std::string& name) {
   tool_ = xtp::QMTools().Create(name);
 }
-void XtpTools::AddCommandLineOptions() {
-  namespace propt = boost::program_options;
-  AddProgramOptions()("name,n", propt::value<std::string>(),
-                      "Name of the job to run");
-}
+void XtpTools::AddCommandLineOptions() {}
 
-void XtpTools::EvaluateSpecificOptions() {
-  CheckRequired(
-      "name", "Please provide the job name to run (same as the xyz file name)");
-}
+void XtpTools::EvaluateSpecificOptions() {}
 
 void XtpTools::execute() {
-
-  if (OptionsMap().find("options") != OptionsMap().cend()) {
-    std::string optionsFile = OptionsMap()["options"].as<std::string>();
-    options_.LoadFromXML(optionsFile);
-  } else {
-    // Empty user options
-    tools::Property& opts = options_.add("options", "");
-    opts.add(tool_->Identify(), "");
-  }
-
-  std::string job_name = OptionsMap()["name"].as<std::string>();
-  tools::Property& opts = options_.get("options." + tool_->Identify());
-  opts.add("job_name", job_name);
 
   Index nThreads = OptionsMap()["nthreads"].as<Index>();
 


### PR DESCRIPTION
@baumeier  please acknowledge

This PR removes the `-n` option from tools instead it adds the `-c` options which allows you to change xml options from the commandline via `a.b=value` mutliple options can be changed by separating them with whitespaces. 