### PR TITLE
Update qmm moptions

### DIFF
--- a/share/xtp/xml/qmmm.xml
+++ b/share/xtp/xml/qmmm.xml
@@ -7,7 +7,7 @@
     <job_file help="name of jobfile to which jobs are written" default="qmmm_jobs.xml"/>
     <write_parse>
       <states help="states to write jobs for and which to parse from jobfile" default="n e h"/>
-      <segments help="segments to write jobs for and which to parse from jobfile" default="all" choices="all, index, list of segment indices"/>
+      <segments help="segments to write jobs for and which to parse from jobfile put either the word all or a list of numbers i.e. 0 4 5 etc." default="all"/>
     </write_parse>
   </qmmm>
 </options>

--- a/share/xtp/xml/qmmm.xml
+++ b/share/xtp/xml/qmmm.xml
@@ -7,6 +7,7 @@
     <job_file help="name of jobfile to which jobs are written" default="qmmm_jobs.xml"/>
     <write_parse>
       <states help="states to write jobs for and which to parse from jobfile" default="n e h"/>
+      <segments help="segments to write jobs for and which to parse from jobfile" default="all" choices="all, index, list of segment indices"/>
     </write_parse>
   </qmmm>
 </options>

--- a/share/xtp/xml/qmmm.xml
+++ b/share/xtp/xml/qmmm.xml
@@ -9,5 +9,6 @@
       <states help="states to write jobs for and which to parse from jobfile" default="n e h"/>
       <segments help="segments to write jobs for and which to parse from jobfile put either the word all or a list of numbers i.e. 0 4 5 etc." default="all"/>
     </write_parse>
+    <use_gs_for_ex help="If true uses the ground state geometry for excited states" default="false"/>
   </qmmm>
 </options>

--- a/src/libxtp/jobcalculators/qmmm.cc
+++ b/src/libxtp/jobcalculators/qmmm.cc
@@ -20,6 +20,7 @@
 // Standard includes
 #include <algorithm>
 #include <chrono>
+#include <sstream> 
 
 // Third party includes
 #include <boost/filesystem.hpp>
@@ -51,7 +52,11 @@ void QMMM::ParseSpecificOptions(const tools::Property& options) {
     all_segments_ = true;
   } else {
     all_segments_ = false;
-    segments_ = options.get("write_parse.segments").as<std::vector<Index>>();
+    std::stringstream ss(whichSegments_);
+    Index segID;
+    while(ss >> segID){
+      segments_.push_back(segID);
+    }
   }
 
   bool groundstate_found = std::any_of(
@@ -242,20 +247,20 @@ void QMMM::WriteJobFile(const Topology& top) {
       }
     }
   } else {
-    for( Index segID : segments_){
-     const Segment& seg = top.Segments()[segID];
-     for (const QMState& state : states_){
-       Job job = createJob(seg, state, jobid);
-       job.ToStream(ofs);
-       jobid++;
-     } 
+    for (Index segID : segments_) {
+      const Segment& seg = top.Segments()[segID];
+      for (const QMState& state : states_) {
+        Job job = createJob(seg, state, jobid);
+        job.ToStream(ofs);
+        jobid++;
+      }
     }
   }
 
   ofs << "</jobs>" << std::endl;
   ofs.close();
   std::cout << std::endl
-            << "... ... In total " << jobid + 1 << " jobs" << std::flush;
+            << "... ... In total " << jobid << " jobs" << std::flush;
   return;
 }
 

--- a/src/libxtp/jobcalculators/qmmm.cc
+++ b/src/libxtp/jobcalculators/qmmm.cc
@@ -20,7 +20,7 @@
 // Standard includes
 #include <algorithm>
 #include <chrono>
-#include <sstream> 
+#include <sstream>
 
 // Third party includes
 #include <boost/filesystem.hpp>
@@ -40,6 +40,7 @@ namespace xtp {
 void QMMM::ParseSpecificOptions(const tools::Property& options) {
 
   print_regions_pdb_ = options.get(".print_regions_pdb").as<bool>();
+  use_gs_for_ex_ = options.get(".use_gs_for_ex").as<bool>();
   max_iterations_ = options.get(".max_iterations").as<Index>();
   regions_def_ = options.get(".regions");
 
@@ -54,7 +55,7 @@ void QMMM::ParseSpecificOptions(const tools::Property& options) {
     all_segments_ = false;
     std::stringstream ss(whichSegments_);
     Index segID;
-    while(ss >> segID){
+    while (ss >> segID) {
       segments_.push_back(segID);
     }
   }
@@ -277,7 +278,12 @@ Job QMMM::createJob(const Segment& seg, const QMState& state, Index jobid) {
   if (hasQMRegion()) {
     region.add("state", state.ToString());
   }
-  region.add("segments", marker);
+  if (use_gs_for_ex_ && (state.Type() == QMStateType::Singlet ||
+                         state.Type() == QMStateType::Triplet)) {
+    region.add("segments", std::to_string(seg.getId()) + ":n");
+  } else {
+    region.add("segments", marker);
+  }
   Job job(jobid, tag, Input, Job::AVAILABLE);
   return job;
 }

--- a/src/libxtp/jobcalculators/qmmm.h
+++ b/src/libxtp/jobcalculators/qmmm.h
@@ -54,7 +54,7 @@ class QMMM final : public ParallelXJobCalc<std::vector<Job> > {
   bool print_regions_pdb_ = false;
 
   bool write_parse_ = true;
-  bool use_gs_for_ex_ = true;
+  bool use_gs_for_ex_ = false;
   std::vector<QMState> states_;
   std::string whichSegments_;
   std::vector<Index> segments_;

--- a/src/libxtp/jobcalculators/qmmm.h
+++ b/src/libxtp/jobcalculators/qmmm.h
@@ -54,6 +54,7 @@ class QMMM final : public ParallelXJobCalc<std::vector<Job> > {
   bool print_regions_pdb_ = false;
 
   bool write_parse_ = true;
+  bool use_gs_for_ex_ = true;
   std::vector<QMState> states_;
   std::string whichSegments_;
   std::vector<Index> segments_;

--- a/src/libxtp/jobcalculators/qmmm.h
+++ b/src/libxtp/jobcalculators/qmmm.h
@@ -47,6 +47,7 @@ class QMMM final : public ParallelXJobCalc<std::vector<Job> > {
 
  private:
   bool hasQMRegion() const;
+  Job createJob(const Segment& seg, const QMState& state, Index jobid);
   tools::Property regions_def_;
 
   Index max_iterations_;
@@ -54,6 +55,9 @@ class QMMM final : public ParallelXJobCalc<std::vector<Job> > {
 
   bool write_parse_ = true;
   std::vector<QMState> states_;
+  std::string whichSegments_;
+  std::vector<Index> segments_;
+  bool all_segments_ = true;
 };
 
 }  // namespace xtp


### PR DESCRIPTION
While preparing the tutorial we found it hard to do a QMMM calculation on a few or just one segment. I have added an option in the `qmmm` to take care of that.

We also need an option to use ground state geometries for the excited state calculations. Now for an `s1` state calculation the job file will have
```
<segments>0:s1</segments>
```
we also want it to be able to print `<segments>0:n</segments>` for the `s1` state. This option will be added shortly
