### PR TITLE
Fixed Typo in gwbse.xml

### DIFF
--- a/share/xtp/xml/subpackages/gwbse.xml
+++ b/share/xtp/xml/subpackages/gwbse.xml
@@ -52,7 +52,7 @@
 
     <fragments help="fragment definitions for bse analysis" default="OPTIONAL" list="">
       <fragment>
-        <indices help="indeces of atoms in this fragment, e.g. 1 3 13:17" default="REQUIRED" />
+        <indices help="indices of atoms in this fragment, e.g. 1 3 13:17" default="REQUIRED" />
       </fragment>
     </fragments>
   </bse>

--- a/share/xtp/xml/subpackages/gwbse.xml
+++ b/share/xtp/xml/subpackages/gwbse.xml
@@ -52,7 +52,7 @@
 
     <fragments help="fragment definitions for bse analysis" default="OPTIONAL" list="">
       <fragment>
-        <indeces help="indeces of atoms in this fragment, e.g. 1 3 13:17" default="REQUIRED" />
+        <indices help="indeces of atoms in this fragment, e.g. 1 3 13:17" default="REQUIRED" />
       </fragment>
     </fragments>
   </bse>


### PR DESCRIPTION
Gianluca found a typo in one of the default files. This is the fix.